### PR TITLE
Fix LayerControl to respect user-provided layerStates option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export type {
   LayerControlOptions,
   LayerState,
   LayerStates,
+  PartialLayerState,
+  PartialLayerStates,
   StyleableLayerType,
   PaintProperty,
   StyleControlConfig,

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -368,10 +368,14 @@ export class LayerControl implements IControl {
         const opacity = getLayerOpacity(this.map, layerId, layerType);
         const friendlyName = this.generateFriendlyName(layerId);
 
+        // Merge with user-provided layerStates if present
+        const existing = this.state.layerStates[layerId];
         this.state.layerStates[layerId] = {
-          visible: isVisible,
-          opacity: opacity,
-          name: friendlyName
+          visible: existing?.visible ?? isVisible,
+          opacity: existing?.opacity ?? opacity,
+          name: existing?.name ?? friendlyName,
+          ...( existing?.isCustomLayer !== undefined ? { isCustomLayer: existing.isCustomLayer } : {}),
+          ...( existing?.customLayerType !== undefined ? { customLayerType: existing.customLayerType } : {}),
         };
       });
     } else {
@@ -418,10 +422,14 @@ export class LayerControl implements IControl {
         // Generate friendly name from layer ID
         const friendlyName = this.generateFriendlyName(layerId);
 
+        // Merge with user-provided layerStates if present
+        const existing = this.state.layerStates[layerId];
         this.state.layerStates[layerId] = {
-          visible: isVisible,
-          opacity: opacity,
-          name: friendlyName
+          visible: existing?.visible ?? isVisible,
+          opacity: existing?.opacity ?? opacity,
+          name: existing?.name ?? friendlyName,
+          ...( existing?.isCustomLayer !== undefined ? { isCustomLayer: existing.isCustomLayer } : {}),
+          ...( existing?.customLayerType !== undefined ? { customLayerType: existing.customLayerType } : {}),
         };
       });
     }

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -2,6 +2,7 @@ import type { IControl, Map as MapLibreMap, LayerSpecification } from 'maplibre-
 import type {
   LayerControlOptions,
   LayerState,
+  PartialLayerStates,
   OriginalStyle,
   InternalControlState,
   CustomLayerAdapter,
@@ -39,6 +40,7 @@ export class LayerControl implements IControl {
   private styleEditors: Map<string, HTMLElement>;
   private initialSourceIds: Set<string> | null = null;
   private initialLayerIds: Set<string> | null = null;
+  private initialLayerStates: PartialLayerStates;
 
   // Panel width management
   private minPanelWidth: number;
@@ -89,11 +91,13 @@ export class LayerControl implements IControl {
     this.onLayerReorder = options.onLayerReorder;
     this.onLayerRemove = options.onLayerRemove;
 
+    this.initialLayerStates = options.layerStates || {};
+
     this.state = {
       collapsed: options.collapsed !== false,
       panelWidth: options.panelWidth || 350,
       activeStyleEditor: null,
-      layerStates: options.layerStates || {},
+      layerStates: {},
       originalStyles: new Map<string, OriginalStyle>(),
       userInteractingWithSlider: false,
       backgroundLegendOpen: false,
@@ -118,7 +122,7 @@ export class LayerControl implements IControl {
       isStyleOperationInProgress: false,
     };
 
-    this.targetLayers = options.layers || Object.keys(this.state.layerStates);
+    this.targetLayers = options.layers || Object.keys(this.initialLayerStates);
     this.styleEditors = new Map<string, HTMLElement>();
 
     // Initialize custom layer registry if adapters are provided
@@ -368,15 +372,11 @@ export class LayerControl implements IControl {
         const opacity = getLayerOpacity(this.map, layerId, layerType);
         const friendlyName = this.generateFriendlyName(layerId);
 
-        // Merge with user-provided layerStates if present
-        const existing = this.state.layerStates[layerId];
-        this.state.layerStates[layerId] = {
-          visible: existing?.visible ?? isVisible,
-          opacity: existing?.opacity ?? opacity,
-          name: existing?.name ?? friendlyName,
-          ...( existing?.isCustomLayer !== undefined ? { isCustomLayer: existing.isCustomLayer } : {}),
-          ...( existing?.customLayerType !== undefined ? { customLayerType: existing.customLayerType } : {}),
-        };
+        this.state.layerStates[layerId] = this.mergeWithUserState(layerId, {
+          visible: isVisible,
+          opacity: opacity,
+          name: friendlyName,
+        });
       });
     } else {
       // Specific layers requested - separate into user layers + Background
@@ -411,26 +411,17 @@ export class LayerControl implements IControl {
         const layer = this.map.getLayer(layerId);
         if (!layer) return;
 
-        // Get visibility
         const visibility = this.map.getLayoutProperty(layerId, 'visibility');
         const isVisible = visibility !== 'none';
-
-        // Get opacity
         const layerType = layer.type;
         const opacity = getLayerOpacity(this.map, layerId, layerType);
-
-        // Generate friendly name from layer ID
         const friendlyName = this.generateFriendlyName(layerId);
 
-        // Merge with user-provided layerStates if present
-        const existing = this.state.layerStates[layerId];
-        this.state.layerStates[layerId] = {
-          visible: existing?.visible ?? isVisible,
-          opacity: existing?.opacity ?? opacity,
-          name: existing?.name ?? friendlyName,
-          ...( existing?.isCustomLayer !== undefined ? { isCustomLayer: existing.isCustomLayer } : {}),
-          ...( existing?.customLayerType !== undefined ? { customLayerType: existing.customLayerType } : {}),
-        };
+        this.state.layerStates[layerId] = this.mergeWithUserState(layerId, {
+          visible: isVisible,
+          opacity: opacity,
+          name: friendlyName,
+        });
       });
     }
 
@@ -591,6 +582,23 @@ export class LayerControl implements IControl {
     name = name.replace(/\b\w/g, char => char.toUpperCase());
 
     return name || layerId; // Fallback to original if empty
+  }
+
+  /**
+   * Merge auto-detected layer state with user-provided initial state.
+   * User-provided values take precedence over detected values.
+   */
+  private mergeWithUserState(layerId: string, detected: LayerState): LayerState {
+    const userState = this.initialLayerStates[layerId];
+    if (!userState) return detected;
+
+    return {
+      visible: userState.visible ?? detected.visible,
+      opacity: userState.opacity ?? detected.opacity,
+      name: userState.name ?? detected.name,
+      ...(userState.isCustomLayer !== undefined && { isCustomLayer: userState.isCustomLayer }),
+      ...(userState.customLayerType !== undefined && { customLayerType: userState.customLayerType }),
+    };
   }
 
   /**

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -24,6 +24,19 @@ export interface LayerStates {
 }
 
 /**
+ * Partial layer state for user-provided initial configuration.
+ * Users can specify only the properties they want to override (e.g., just `name`).
+ */
+export type PartialLayerState = Partial<LayerState>;
+
+/**
+ * Collection of partial layer states keyed by layer ID (for options input)
+ */
+export interface PartialLayerStates {
+  [layerId: string]: PartialLayerState;
+}
+
+/**
  * Adapter interface for custom (non-MapLibre) layers.
  * Implement this interface to integrate custom layer types (e.g., deck.gl layers)
  * with the layer control.
@@ -90,8 +103,8 @@ export interface OriginalStyle {
 export interface LayerControlOptions {
   /** Whether the control starts collapsed (default: true) */
   collapsed?: boolean;
-  /** Initial layer states (keyed by layer ID) */
-  layerStates?: LayerStates;
+  /** Initial layer states (keyed by layer ID). Partial values are accepted; unspecified fields will be auto-detected from the map. */
+  layerStates?: PartialLayerStates;
   /** Array of layer IDs to control (if not specified, controls all layers) */
   layers?: string[];
   /** Initial panel width in pixels (default: 320) */


### PR DESCRIPTION
## Summary
- When `layerStates` was passed as an option to `LayerControl`, the `autoDetectLayers()` method unconditionally overwrote user-provided values (name, visible, opacity) with auto-generated ones
- Now the code merges user-provided values with map-detected values using nullish coalescing (`??`), preferring user-provided settings when present
- Applies to both auto-detected layers and user-specified layers code paths

Fixes #44

## Test plan
- [ ] Create a `LayerControl` with `layerStates` option specifying custom names for specific layers
- [ ] Verify the custom names appear in the layer list instead of auto-generated `friendlyName` values
- [ ] Verify layers without user-provided `layerStates` still get auto-generated names
- [ ] Verify user-provided `visible` and `opacity` values are respected