### PR TITLE
ci: publish to npm via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,14 @@ name: Publish to npm
 on:
   release:
     types: [created]
+  # Allow re-publishing the current package.json version manually (e.g. if a
+  # release-triggered run needs to be retried).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required for npm Trusted Publishing (OIDC) — no NPM_TOKEN needed.
+  id-token: write
 
 jobs:
   publish:
@@ -11,8 +19,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted Publishing requires npm >= 11.5.1, newer than the version
+      # bundled with Node 22.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -23,7 +36,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      # No NODE_AUTH_TOKEN: authentication is via OIDC Trusted Publishing,
+      # configured for this package + workflow on npmjs.com. Provenance is
+      # generated and attached automatically.
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Switches the npm publish workflow from a long-lived `NPM_TOKEN` secret to **npm Trusted Publishing (OIDC)**. The v0.15.0 release publish failed because the `NPM_TOKEN` secret is expired/invalid; trusted publishing removes the token entirely.

### Workflow changes
- Add `permissions: id-token: write` (and `contents: read`).
- Drop `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN`.
- Update npm to `latest` (Trusted Publishing needs npm >= 11.5.1; bumped Node to 22).
- Add `workflow_dispatch` so a failed release publish can be retried without re-cutting the release.

### One-time setup required on npmjs.com (maintainer)
On the package page → **Settings → Trusted Publisher**, add a GitHub Actions publisher:
- Organization/owner: `opengeos`
- Repository: `maplibre-gl-layer-control`
- Workflow filename: `publish.yml`
- Environment: *(leave blank)*

After that's configured and this PR is merged, run the **Publish to npm** workflow via *Run workflow* (or I can dispatch it) to publish the pending 0.15.0.