### PR TITLE
ci: drop registry-url so OIDC Trusted Publishing engages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # Note: no `registry-url` here. setup-node's registry-url writes an
+      # .npmrc with `_authToken=${NODE_AUTH_TOKEN}`; with no token that
+      # placeholder is used as the credential and npm never falls back to
+      # OIDC. Omitting it lets Trusted Publishing (OIDC) authenticate against
+      # the default registry.npmjs.org.
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       # Trusted Publishing requires npm >= 11.5.1, newer than the version
       # bundled with Node 22.


### PR DESCRIPTION
Follow-up to #50. The publish kept failing with E404 because `actions/setup-node`'s `registry-url` writes an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`. With no token, the masked placeholder is used as the credential, so npm authenticates by (invalid) token and never falls back to OIDC. Removing `registry-url` lets Trusted Publishing authenticate via OIDC against the default registry.npmjs.org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow configuration for improved authentication security during release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->