### PR TITLE
ci: update npm publish workflow for Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,33 +3,19 @@ name: Publish to npm
 on:
   release:
     types: [created]
-  # Allow re-publishing the current package.json version manually (e.g. if a
-  # release-triggered run needs to be retried).
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  # Required for npm Trusted Publishing (OIDC) — no NPM_TOKEN needed.
-  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
-      # Note: no `registry-url` here. setup-node's registry-url writes an
-      # .npmrc with `_authToken=${NODE_AUTH_TOKEN}`; with no token that
-      # placeholder is used as the credential and npm never falls back to
-      # OIDC. Omitting it lets Trusted Publishing (OIDC) authenticate against
-      # the default registry.npmjs.org.
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
-
-      # Trusted Publishing requires npm >= 11.5.1, newer than the version
-      # bundled with Node 22.
-      - name: Update npm
-        run: npm install -g npm@latest
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -40,8 +26,5 @@ jobs:
       - name: Build
         run: npm run build
 
-      # No NODE_AUTH_TOKEN: authentication is via OIDC Trusted Publishing,
-      # configured for this package + workflow on npmjs.com. Provenance is
-      # generated and attached automatically.
       - name: Publish to npm
-        run: npm publish
+        run: npx -y npm@latest publish --provenance --access public


### PR DESCRIPTION
- Change Node.js version to 24 and set registry-url for npm
- Use npx to publish with provenance and public access
- Remove unnecessary comments and streamline permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated package publishing to npm now triggers on GitHub Releases.
  * Enhanced package publishing security with provenance attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->