### PR TITLE
fix: restore toggle-button icon sizing (regression from #47)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-layer-control",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A comprehensive layer control for MapLibre GL with advanced styling capabilities",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/styles/layer-control.css
+++ b/src/lib/styles/layer-control.css
@@ -1,5 +1,25 @@
 /* Layer Control Styles */
 
+/* Toggle button icon. Only the icon is sized here; its color is intentionally
+   left to the host/theme via `currentColor` (the SVG uses stroke="currentColor")
+   so dark-mode themes can recolor it. Without an explicit size the inline SVG
+   renders at the full button size, so cap it. */
+.maplibregl-ctrl-layer-control .layer-control-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  line-height: 0;
+}
+
+.maplibregl-ctrl-layer-control .layer-control-icon svg {
+  width: 22px;
+  height: 22px;
+  stroke: currentColor;
+  fill: none;
+}
+
 /* Panel - positioned dynamically by JavaScript for floating behavior */
 .layer-control-panel {
   position: absolute;


### PR DESCRIPTION
PR #47 (\"Remove CSS overwrites\", for \`lhapaipai/maplibre-theme\` dark-mode compatibility) removed **all** toggle-button overrides — including the inline SVG's size. Without a size, the layers icon renders at the full button size (≈29px instead of 22px), so it looks oversized in any consumer.

This restores **only the icon sizing** (22×22, centered). Color is deliberately left to the host/theme via \`currentColor\` (the SVG already uses \`stroke="currentColor"\`), so the dark-mode theme compatibility from #47 is preserved.

Bumps to 0.15.1.