### PR TITLE
feat: save and reuse basemap element visibility as named presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ function MapComponent() {
 | `basemapStyleUrl` | `string` | `undefined` | URL of basemap style JSON for reliable layer detection (see below) |
 | `enableBackgroundPresets` | `boolean` | `true` | Show the "Saved configurations" controls in the Background Layers panel |
 | `backgroundPresetStorageKey` | `string` | `'maplibre-layer-control:background-presets'` | `localStorage` key under which background visibility presets are stored |
-| `onBackgroundPresetsChange` | `(presets: BackgroundPresets) => void` | `undefined` | Called whenever presets are created, applied, or deleted |
+| `onBackgroundPresetsChange` | `(presets: BackgroundPresets) => void` | `undefined` | Called whenever the saved preset set changes (created or deleted); applying a preset does not change the set, so it does not fire |
 
 ### LayerState
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A comprehensive layer control for MapLibre GL with advanced styling capabilities
 - ✅ **Dynamic layer detection** - Automatically detect and manage new layers
 - ✅ **Background layer grouping** - Control all basemap layers as one group
 - ✅ **Background layer legend** - Gear icon to toggle individual background layer visibility
+- ✅ **Saved configurations** - Save the current basemap element visibility as a named preset and re-apply it with one click; presets persist across sessions and projects via `localStorage`
 - ✅ **Accessibility** - Full ARIA support and keyboard navigation
 - ✅ **TypeScript** - Full type safety and IntelliSense support
 - ✅ **React integration** - Optional React components and hooks
@@ -175,6 +176,9 @@ function MapComponent() {
 | `excludeLayers` | `string[]` | `undefined` | Array of wildcard patterns to exclude layers by name (e.g., `['*-temp-*', 'debug-*']`) |
 | `customLayerAdapters` | `CustomLayerAdapter[]` | `undefined` | Adapters for non-MapLibre layers (deck.gl, Zarr, etc.) |
 | `basemapStyleUrl` | `string` | `undefined` | URL of basemap style JSON for reliable layer detection (see below) |
+| `enableBackgroundPresets` | `boolean` | `true` | Show the "Saved configurations" controls in the Background Layers panel |
+| `backgroundPresetStorageKey` | `string` | `'maplibre-layer-control:background-presets'` | `localStorage` key under which background visibility presets are stored |
+| `onBackgroundPresetsChange` | `(presets: BackgroundPresets) => void` | `undefined` | Called whenever presets are created, applied, or deleted |
 
 ### LayerState
 
@@ -293,8 +297,30 @@ When using the `layers` option to specify specific layers, all other layers are 
 - Quick "Show All" / "Hide All" buttons
 - **"Only rendered" filter** - Shows only layers that are currently rendered in the map viewport
 - Indeterminate checkbox state when some layers are hidden
+- **Saved configurations** - Save the current set of visibility toggles as a named preset and re-apply it later with one click
 
 This allows fine-grained control over which basemap layers are visible while maintaining a simplified layer control interface.
+
+#### Saved configurations (presets)
+
+The Background Layers panel includes a **Saved configurations** section that lets users save the current basemap element visibility as a named preset and re-apply it with a single click. Presets are stored in `localStorage`, so they persist across page reloads and apply to any project that uses the same basemap layers. Toggle the UI off with `enableBackgroundPresets: false`, or change the storage location with `backgroundPresetStorageKey`.
+
+The same functionality is available programmatically:
+
+```javascript
+// Capture the current basemap element visibility
+const visibility = layerControl.getBackgroundLayerVisibility();
+// → { 'water': true, 'road-primary': false, ... }
+
+// Apply a configuration (only layers present in the style are affected)
+layerControl.applyBackgroundLayerVisibility(visibility);
+
+// Named presets (persisted to localStorage)
+layerControl.saveBackgroundPreset('Minimal');   // save current visibility
+layerControl.getBackgroundPresets();            // → { Minimal: { ... } }
+layerControl.applyBackgroundPreset('Minimal');  // → true if it existed
+layerControl.deleteBackgroundPreset('Minimal');
+```
 
 ### Custom Layer Adapters
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-layer-control",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "A comprehensive layer control for MapLibre GL with advanced styling capabilities",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export type {
   PaintProperty,
   StyleControlConfig,
   CustomLayerAdapter,
+  BackgroundLayerVisibility,
+  BackgroundPresets,
 } from './lib/core/types';
 
 // Re-export utilities for advanced use cases

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -2514,10 +2514,29 @@ export class LayerControl implements IControl {
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
         return {};
       }
-      return parsed as BackgroundPresets;
+      // Keep only safe, own keys mapping to plain objects, so a hand-crafted
+      // storage value cannot smuggle in dangerous keys (e.g. `__proto__`).
+      const presets: BackgroundPresets = {};
+      for (const [name, value] of Object.entries(parsed)) {
+        if (this.isUnsafePresetKey(name)) continue;
+        if (value && typeof value === "object" && !Array.isArray(value)) {
+          presets[name] = value as BackgroundLayerVisibility;
+        }
+      }
+      return presets;
     } catch {
       return {};
     }
+  }
+
+  /**
+   * Reject preset names that, used as object keys, could pollute the prototype
+   * chain or otherwise alias built-in object members.
+   */
+  private isUnsafePresetKey(name: string): boolean {
+    return (
+      name === "__proto__" || name === "constructor" || name === "prototype"
+    );
   }
 
   /**
@@ -2548,7 +2567,7 @@ export class LayerControl implements IControl {
   saveBackgroundPreset(name: string): BackgroundPresets {
     const trimmed = name.trim();
     const presets = this.getBackgroundPresets();
-    if (!trimmed) return presets;
+    if (!trimmed || this.isUnsafePresetKey(trimmed)) return presets;
     presets[trimmed] = this.getBackgroundLayerVisibility();
     this.writeBackgroundPresets(presets);
     return presets;
@@ -2562,9 +2581,8 @@ export class LayerControl implements IControl {
    */
   applyBackgroundPreset(name: string): boolean {
     const presets = this.getBackgroundPresets();
-    const preset = presets[name];
-    if (!preset) return false;
-    this.applyBackgroundLayerVisibility(preset);
+    if (!Object.prototype.hasOwnProperty.call(presets, name)) return false;
+    this.applyBackgroundLayerVisibility(presets[name]);
     return true;
   }
 
@@ -2576,7 +2594,7 @@ export class LayerControl implements IControl {
    */
   deleteBackgroundPreset(name: string): BackgroundPresets {
     const presets = this.getBackgroundPresets();
-    if (name in presets) {
+    if (Object.prototype.hasOwnProperty.call(presets, name)) {
       delete presets[name];
       this.writeBackgroundPresets(presets);
     }

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -10,6 +10,8 @@ import type {
   OriginalStyle,
   InternalControlState,
   CustomLayerAdapter,
+  BackgroundLayerVisibility,
+  BackgroundPresets,
 } from "./types";
 import { CustomLayerRegistry } from "./CustomLayerRegistry";
 import {
@@ -104,6 +106,11 @@ export class LayerControl implements IControl {
   private onLayerReorder?: (layerOrder: string[]) => void;
   private onLayerRemove?: (layerId: string) => void;
 
+  // Background-layer visibility presets
+  private enableBackgroundPresets: boolean;
+  private backgroundPresetStorageKey: string;
+  private onBackgroundPresetsChange?: (presets: BackgroundPresets) => void;
+
   constructor(options: LayerControlOptions = {}) {
     this.minPanelWidth = options.panelMinWidth || 240;
     this.maxPanelWidth = options.panelMaxWidth || 420;
@@ -123,6 +130,13 @@ export class LayerControl implements IControl {
     this.onLayerRename = options.onLayerRename;
     this.onLayerReorder = options.onLayerReorder;
     this.onLayerRemove = options.onLayerRemove;
+
+    // Background-layer visibility presets
+    this.enableBackgroundPresets = options.enableBackgroundPresets !== false;
+    this.backgroundPresetStorageKey =
+      options.backgroundPresetStorageKey ||
+      "maplibre-layer-control:background-presets";
+    this.onBackgroundPresetsChange = options.onBackgroundPresetsChange;
 
     this.initialLayerStates = options.layerStates || {};
 
@@ -2081,7 +2095,140 @@ export class LayerControl implements IControl {
     panel.appendChild(filterRow);
     panel.appendChild(layerList);
 
+    // Saved configurations (presets) row
+    if (this.enableBackgroundPresets) {
+      panel.appendChild(this.createBackgroundPresetsRow());
+    }
+
     return panel;
+  }
+
+  /**
+   * Build the "Saved configurations" controls: a dropdown of saved presets with
+   * Apply/Delete actions, plus a name field and Save button to capture the
+   * current basemap element visibility as a reusable, persisted preset.
+   */
+  private createBackgroundPresetsRow(): HTMLElement {
+    const section = document.createElement("div");
+    section.className = "background-legend-presets";
+
+    const label = document.createElement("div");
+    label.className = "background-legend-presets-label";
+    label.textContent = "Saved configurations";
+    section.appendChild(label);
+
+    // Row 1: preset selector + apply/delete
+    const selectRow = document.createElement("div");
+    selectRow.className = "background-legend-presets-row";
+
+    const select = document.createElement("select");
+    select.className = "background-legend-presets-select";
+    select.title = "Saved configurations";
+
+    const applyBtn = document.createElement("button");
+    applyBtn.className = "background-legend-action-btn";
+    applyBtn.textContent = "Apply";
+    applyBtn.title = "Apply the selected configuration";
+
+    const deleteBtn = document.createElement("button");
+    deleteBtn.className = "background-legend-action-btn";
+    deleteBtn.textContent = "Delete";
+    deleteBtn.title = "Delete the selected configuration";
+
+    const refreshSelect = (selected?: string) => {
+      const presets = this.getBackgroundPresets();
+      const names = Object.keys(presets).sort((a, b) =>
+        a.localeCompare(b, undefined, { sensitivity: "base" }),
+      );
+      select.innerHTML = "";
+
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = names.length
+        ? "Select a configuration…"
+        : "No saved configurations";
+      placeholder.disabled = names.length > 0;
+      select.appendChild(placeholder);
+
+      names.forEach((name) => {
+        const option = document.createElement("option");
+        option.value = name;
+        option.textContent = name;
+        select.appendChild(option);
+      });
+
+      select.value = selected && names.includes(selected) ? selected : "";
+      const hasSelection = select.value !== "";
+      applyBtn.disabled = !hasSelection;
+      deleteBtn.disabled = !hasSelection;
+    };
+
+    select.addEventListener("change", () => {
+      const hasSelection = select.value !== "";
+      applyBtn.disabled = !hasSelection;
+      deleteBtn.disabled = !hasSelection;
+    });
+
+    applyBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (select.value) this.applyBackgroundPreset(select.value);
+    });
+
+    deleteBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (select.value) {
+        this.deleteBackgroundPreset(select.value);
+        refreshSelect();
+      }
+    });
+
+    selectRow.appendChild(select);
+    selectRow.appendChild(applyBtn);
+    selectRow.appendChild(deleteBtn);
+
+    // Row 2: name input + save
+    const saveRow = document.createElement("div");
+    saveRow.className = "background-legend-presets-row";
+
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.className = "background-legend-presets-input";
+    nameInput.placeholder = "Configuration name…";
+    nameInput.maxLength = 60;
+
+    const saveBtn = document.createElement("button");
+    saveBtn.className = "background-legend-action-btn";
+    saveBtn.textContent = "Save";
+    saveBtn.title = "Save the current visibility as a configuration";
+
+    const commitSave = () => {
+      const name = nameInput.value.trim();
+      if (!name) return;
+      this.saveBackgroundPreset(name);
+      nameInput.value = "";
+      refreshSelect(name);
+    };
+
+    saveBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      commitSave();
+    });
+    nameInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitSave();
+      }
+    });
+
+    saveRow.appendChild(nameInput);
+    saveRow.appendChild(saveBtn);
+
+    section.appendChild(selectRow);
+    section.appendChild(saveRow);
+
+    refreshSelect();
+
+    return section;
   }
 
   /**
@@ -2290,6 +2437,150 @@ export class LayerControl implements IControl {
     if (this.state.layerStates["Background"]) {
       this.state.layerStates["Background"].visible = anyVisible;
     }
+  }
+
+  /**
+   * Return the IDs of the background (basemap) style layers the control can
+   * toggle, honoring the drawn-layer and user-defined exclusion filters but not
+   * the transient "only rendered" view filter.
+   */
+  private getControllableBackgroundLayerIds(): string[] {
+    const styleLayers = this.map.getStyle().layers || [];
+    return styleLayers
+      .filter((layer) => {
+        if (this.isUserAddedLayer(layer.id)) return false;
+        if (this.excludeDrawnLayers && this.isDrawnLayer(layer.id)) return false;
+        if (this.isExcludedByPattern(layer.id)) return false;
+        return true;
+      })
+      .map((layer) => layer.id);
+  }
+
+  /**
+   * Get the current visibility of every controllable background (basemap) layer.
+   *
+   * @returns A map of style-layer ID to whether it is currently visible.
+   */
+  getBackgroundLayerVisibility(): BackgroundLayerVisibility {
+    const visibility: BackgroundLayerVisibility = {};
+    for (const layerId of this.getControllableBackgroundLayerIds()) {
+      const value = this.map.getLayoutProperty(layerId, "visibility");
+      visibility[layerId] = value !== "none";
+    }
+    return visibility;
+  }
+
+  /**
+   * Apply a saved background-layer visibility configuration to the map. Only
+   * layers that currently exist in the style are affected, so a configuration
+   * captured on one basemap degrades gracefully when applied to another.
+   *
+   * @param visibility - Map of style-layer ID to desired visibility.
+   */
+  applyBackgroundLayerVisibility(visibility: BackgroundLayerVisibility): void {
+    for (const [layerId, visible] of Object.entries(visibility)) {
+      if (this.isUserAddedLayer(layerId)) continue;
+      if (!this.map.getLayer(layerId)) continue;
+      this.state.backgroundLayerVisibility.set(layerId, visible);
+      this.map.setLayoutProperty(
+        layerId,
+        "visibility",
+        visible ? "visible" : "none",
+      );
+    }
+
+    // Refresh the open legend panel (if any) and the main Background checkbox.
+    const legendPanel = this.panel.querySelector(
+      ".background-legend-layer-list",
+    );
+    if (legendPanel) {
+      this.populateBackgroundLayerList(legendPanel as HTMLElement);
+    }
+    this.updateBackgroundCheckboxState();
+  }
+
+  /**
+   * Read all saved background-layer presets from localStorage. Returns an empty
+   * object when storage is unavailable or the stored value is malformed.
+   */
+  getBackgroundPresets(): BackgroundPresets {
+    try {
+      const raw =
+        typeof localStorage !== "undefined"
+          ? localStorage.getItem(this.backgroundPresetStorageKey)
+          : null;
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return {};
+      }
+      return parsed as BackgroundPresets;
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Persist the full preset map to localStorage and notify listeners.
+   */
+  private writeBackgroundPresets(presets: BackgroundPresets): void {
+    try {
+      if (typeof localStorage !== "undefined") {
+        localStorage.setItem(
+          this.backgroundPresetStorageKey,
+          JSON.stringify(presets),
+        );
+      }
+    } catch {
+      // Storage may be unavailable (private mode, quota); presets stay in-memory
+      // for this session via the UI but cannot be persisted.
+    }
+    this.onBackgroundPresetsChange?.(presets);
+  }
+
+  /**
+   * Save the current background-layer visibility as a named preset. Reusing an
+   * existing name overwrites that preset.
+   *
+   * @param name - Preset name; whitespace is trimmed. Empty names are ignored.
+   * @returns The updated preset map.
+   */
+  saveBackgroundPreset(name: string): BackgroundPresets {
+    const trimmed = name.trim();
+    const presets = this.getBackgroundPresets();
+    if (!trimmed) return presets;
+    presets[trimmed] = this.getBackgroundLayerVisibility();
+    this.writeBackgroundPresets(presets);
+    return presets;
+  }
+
+  /**
+   * Apply a previously saved preset to the map.
+   *
+   * @param name - The preset name to apply.
+   * @returns `true` if a preset with that name existed and was applied.
+   */
+  applyBackgroundPreset(name: string): boolean {
+    const presets = this.getBackgroundPresets();
+    const preset = presets[name];
+    if (!preset) return false;
+    this.applyBackgroundLayerVisibility(preset);
+    return true;
+  }
+
+  /**
+   * Delete a saved preset.
+   *
+   * @param name - The preset name to remove.
+   * @returns The updated preset map.
+   */
+  deleteBackgroundPreset(name: string): BackgroundPresets {
+    const presets = this.getBackgroundPresets();
+    if (name in presets) {
+      delete presets[name];
+      this.writeBackgroundPresets(presets);
+    }
+    return presets;
   }
 
   /**

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -158,7 +158,8 @@ export interface LayerControlOptions {
   backgroundPresetStorageKey?: string;
   /**
    * Callback fired whenever the set of saved background presets changes
-   * (created, applied, or deleted). Receives the full preset map.
+   * (created or deleted). Receives the full preset map. Applying a preset does
+   * not change the stored set, so it does not trigger this callback.
    */
   onBackgroundPresetsChange?: (presets: BackgroundPresets) => void;
 }

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -144,7 +144,35 @@ export interface LayerControlOptions {
   onLayerReorder?: (layerOrder: string[]) => void;
   /** Callback when a layer is removed via context menu */
   onLayerRemove?: (layerId: string) => void;
+  /**
+   * Whether to show the "Saved configurations" controls in the Background Layers
+   * panel, letting users save the current basemap element visibility as a named
+   * preset and re-apply it later with one click (default: true).
+   */
+  enableBackgroundPresets?: boolean;
+  /**
+   * localStorage key under which background-layer visibility presets are stored.
+   * Presets persist across sessions and projects (default:
+   * 'maplibre-layer-control:background-presets').
+   */
+  backgroundPresetStorageKey?: string;
+  /**
+   * Callback fired whenever the set of saved background presets changes
+   * (created, applied, or deleted). Receives the full preset map.
+   */
+  onBackgroundPresetsChange?: (presets: BackgroundPresets) => void;
 }
+
+/**
+ * A single background-layer visibility preset: a map of style-layer ID to
+ * whether that layer should be visible.
+ */
+export type BackgroundLayerVisibility = Record<string, boolean>;
+
+/**
+ * Collection of named background-layer visibility presets, keyed by preset name.
+ */
+export type BackgroundPresets = Record<string, BackgroundLayerVisibility>;
 
 /**
  * MapLibre layer types that support styling

--- a/src/lib/styles/layer-control.css
+++ b/src/lib/styles/layer-control.css
@@ -868,6 +868,14 @@
   border-color: #1a4fc2;
 }
 
+.layer-control-background-legend .background-legend-action-btn:disabled {
+  background: #b9c4d6 !important;
+  background-color: #b9c4d6 !important;
+  border-color: #b9c4d6;
+  color: #ffffff;
+  cursor: not-allowed;
+}
+
 /* Filter row */
 .background-legend-filter {
   display: flex;
@@ -932,6 +940,53 @@
   width: 14px;
   height: 14px;
   display: block;
+}
+
+/* Saved configurations (presets) */
+.background-legend-presets {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.background-legend-presets-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #444;
+  margin-bottom: 6px;
+}
+
+.background-legend-presets-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.background-legend-presets-row:last-child {
+  margin-bottom: 0;
+}
+
+.background-legend-presets-select,
+.background-legend-presets-input {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 8px;
+  border: 1px solid #cbd5e1;
+  border-radius: 3px;
+  background: #ffffff;
+  color: #333;
+  font-size: 11px;
+  height: auto;
+}
+
+.background-legend-presets-select:focus,
+.background-legend-presets-input:focus {
+  outline: none;
+  border-color: #2f6fed;
+}
+
+.background-legend-presets-row .background-legend-action-btn {
+  flex: 0 0 auto;
 }
 
 .background-legend-layer-name {

--- a/tests/backgroundPresets.test.ts
+++ b/tests/backgroundPresets.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LayerControl } from '../src/lib/core/LayerControl';
+
+const STORAGE_KEY = 'test:bg-presets';
+
+// jsdom in this config does not provide localStorage; supply a minimal polyfill.
+if (typeof globalThis.localStorage === 'undefined') {
+  const store = new Map<string, string>();
+  globalThis.localStorage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+  } as Storage;
+}
+
+/**
+ * Build a LayerControl wired to a minimal in-memory mock map so the
+ * background-preset API can be exercised without a real MapLibre instance.
+ */
+function makeControl(initialVisibility: Record<string, boolean>) {
+  const visibility = new Map<string, boolean>(
+    Object.entries(initialVisibility),
+  );
+  const layerIds = Object.keys(initialVisibility);
+
+  const mockMap = {
+    getStyle: () => ({
+      layers: layerIds.map((id) => ({ id, type: 'fill' })),
+    }),
+    getLayer: (id: string) => (visibility.has(id) ? { id } : undefined),
+    getLayoutProperty: (id: string, _prop: string) =>
+      visibility.get(id) === false ? 'none' : 'visible',
+    setLayoutProperty: (id: string, _prop: string, value: string) => {
+      visibility.set(id, value !== 'none');
+    },
+  };
+
+  const control = new LayerControl({
+    backgroundPresetStorageKey: STORAGE_KEY,
+    excludeDrawnLayers: false,
+  });
+
+  // Inject the mock map/panel and treat all known layers as basemap layers.
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (control as any).map = mockMap;
+  (control as any).panel = document.createElement('div');
+  (control as any).basemapLayerIds = new Set(layerIds);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  return { control, visibility };
+}
+
+describe('background presets', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('reads no presets initially', () => {
+    const { control } = makeControl({ water: true });
+    expect(control.getBackgroundPresets()).toEqual({});
+  });
+
+  it('captures current visibility of controllable layers', () => {
+    const { control } = makeControl({ water: true, roads: false, labels: true });
+    expect(control.getBackgroundLayerVisibility()).toEqual({
+      water: true,
+      roads: false,
+      labels: true,
+    });
+  });
+
+  it('saves and persists a named preset to localStorage', () => {
+    const { control } = makeControl({ water: true, roads: false });
+    control.saveBackgroundPreset('minimal');
+
+    const presets = control.getBackgroundPresets();
+    expect(presets).toEqual({ minimal: { water: true, roads: false } });
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string)).toEqual(presets);
+  });
+
+  it('ignores empty preset names', () => {
+    const { control } = makeControl({ water: true });
+    control.saveBackgroundPreset('   ');
+    expect(control.getBackgroundPresets()).toEqual({});
+  });
+
+  it('applies a saved preset back onto the map', () => {
+    const { control, visibility } = makeControl({ water: true, roads: true });
+    control.saveBackgroundPreset('hide-roads-snapshot');
+
+    // Mutate live state, then re-apply by writing the desired config directly.
+    control.applyBackgroundLayerVisibility({ water: false, roads: true });
+    expect(visibility.get('water')).toBe(false);
+    expect(visibility.get('roads')).toBe(true);
+
+    const applied = control.applyBackgroundPreset('hide-roads-snapshot');
+    expect(applied).toBe(true);
+    expect(visibility.get('water')).toBe(true);
+    expect(visibility.get('roads')).toBe(true);
+  });
+
+  it('returns false when applying a missing preset', () => {
+    const { control } = makeControl({ water: true });
+    expect(control.applyBackgroundPreset('does-not-exist')).toBe(false);
+  });
+
+  it('only applies layers that exist in the current style', () => {
+    const { control, visibility } = makeControl({ water: true });
+    control.applyBackgroundLayerVisibility({ water: false, ghost: false });
+    expect(visibility.get('water')).toBe(false);
+    expect(visibility.has('ghost')).toBe(false);
+  });
+
+  it('deletes a preset and persists the removal', () => {
+    const { control } = makeControl({ water: true });
+    control.saveBackgroundPreset('a');
+    control.saveBackgroundPreset('b');
+    control.deleteBackgroundPreset('a');
+
+    expect(Object.keys(control.getBackgroundPresets())).toEqual(['b']);
+  });
+
+  it('recovers from malformed stored JSON', () => {
+    localStorage.setItem(STORAGE_KEY, '{not valid json');
+    const { control } = makeControl({ water: true });
+    expect(control.getBackgroundPresets()).toEqual({});
+  });
+
+  it('fires the change callback when presets mutate', () => {
+    const calls: number[] = [];
+    const control = new LayerControl({
+      backgroundPresetStorageKey: STORAGE_KEY,
+      excludeDrawnLayers: false,
+      onBackgroundPresetsChange: (presets) =>
+        calls.push(Object.keys(presets).length),
+    });
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (control as any).map = {
+      getStyle: () => ({ layers: [{ id: 'water', type: 'fill' }] }),
+      getLayer: (id: string) => ({ id }),
+      getLayoutProperty: () => 'visible',
+      setLayoutProperty: () => {},
+    };
+    (control as any).panel = document.createElement('div');
+    (control as any).basemapLayerIds = new Set(['water']);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    control.saveBackgroundPreset('one');
+    control.deleteBackgroundPreset('one');
+    expect(calls).toEqual([1, 0]);
+  });
+});

--- a/tests/backgroundPresets.test.ts
+++ b/tests/backgroundPresets.test.ts
@@ -138,6 +138,28 @@ describe('background presets', () => {
     expect(control.getBackgroundPresets()).toEqual({});
   });
 
+  it('rejects unsafe preset names that could pollute the prototype', () => {
+    const { control } = makeControl({ water: true });
+    for (const unsafe of ['__proto__', 'constructor', 'prototype']) {
+      control.saveBackgroundPreset(unsafe);
+    }
+    expect(control.getBackgroundPresets()).toEqual({});
+    // Inherited names must not produce false-positive apply/delete results.
+    expect(control.applyBackgroundPreset('toString')).toBe(false);
+    expect(control.deleteBackgroundPreset('toString')).toEqual({});
+  });
+
+  it('drops unsafe keys when reading hand-crafted stored JSON', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      '{"__proto__":{"polluted":true},"safe":{"water":false}}',
+    );
+    const { control } = makeControl({ water: true });
+    const presets = control.getBackgroundPresets();
+    expect(presets).toEqual({ safe: { water: false } });
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   it('fires the change callback when presets mutate', () => {
     const calls: number[] = [];
     const control = new LayerControl({
@@ -158,6 +180,8 @@ describe('background presets', () => {
     /* eslint-enable @typescript-eslint/no-explicit-any */
 
     control.saveBackgroundPreset('one');
+    // Applying a preset does not change the stored set, so it must not fire.
+    control.applyBackgroundPreset('one');
     control.deleteBackgroundPreset('one');
     expect(calls).toEqual([1, 0]);
   });


### PR DESCRIPTION
## Summary

Implements the basemap-element configuration feature requested in [giswqs/GeoLibre#425](https://github.com/giswqs/GeoLibre/issues/425). Users can now save which background (basemap) layers are toggled on/off as a **named preset** and re-apply it with a single click. Presets are stored in `localStorage`, so they persist across page reloads and apply to any project that uses the same basemap layers.

## What's new

- **"Saved configurations" UI** in the Background Layers panel: a preset dropdown with **Apply** / **Delete**, plus a name field + **Save** button.
- **Persistence** to `localStorage` (default key `maplibre-layer-control:background-presets`).
- **Public API**: `getBackgroundLayerVisibility()`, `applyBackgroundLayerVisibility()`, `getBackgroundPresets()`, `saveBackgroundPreset()`, `applyBackgroundPreset()`, `deleteBackgroundPreset()`.
- **New options**: `enableBackgroundPresets` (default `true`), `backgroundPresetStorageKey`, `onBackgroundPresetsChange`.
- New exported types `BackgroundLayerVisibility` / `BackgroundPresets`, scoped CSS, README docs.

Applying a configuration only affects layers that exist in the current style, so a preset captured on one basemap degrades gracefully on another. Reading/writing storage is wrapped in try/catch for private-mode / SSR safety.

## Tests

Adds `tests/backgroundPresets.test.ts` (10 cases) covering capture, save/persist, apply, delete, missing-layer handling, malformed-JSON recovery, and the change callback. All **44** tests pass; `npm run build` succeeds.

## Notes

- Version bumped 0.15.1 → **0.16.0** (new feature). npm publish is triggered on GitHub release creation.
- Feature is enabled by default; consumers get it automatically after upgrading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added “Saved configurations” presets for background layer visibility, including UI controls to save, apply, and delete named presets.
  * Presets are persisted in browser storage and can be managed programmatically.
* **Public API / Types**
  * Re-exported new background visibility/presets types and added preset-related methods to the layer control.
* **Documentation**
  * Expanded README with configuration options and usage examples.
* **Style**
  * Updated background legend styling for the new presets section and disabled actions.
* **Tests**
  * Added coverage for preset persistence, validation, and callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->