### PR TITLE
fix: match panel layer order to map stacking order

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive layer control for MapLibre GL with advanced styling capabilities
 - ✅ **Layer visibility toggle** - Checkbox control for each layer
 - ✅ **Layer opacity control** - Smooth opacity slider with type-aware property mapping; **double-click the slider to type an exact percentage (0-100%)**
 - ✅ **Layer symbols** - Visual type indicators (colored shapes) next to layer names, auto-detected from layer paint properties
-- ✅ **Resizable panel** - **Drag either edge of the panel to resize it**, plus a width slider and keyboard support
+- ✅ **Resizable panel** - **Drag either edge of the panel to resize it**; double-click an edge to reset to the default width. The panel also grows to fill the available height so long layer lists only scroll once they exceed the map.
 - ✅ **Advanced style editor** - Per-layer-type styling controls:
   - **Fill layers**: color, opacity, outline-color
   - **Line layers**: color, width, opacity, blur
@@ -73,7 +73,7 @@ map.on('load', () => {
     layers: ['my-layer'], // LayerControl auto-detects opacity, visibility, and generates friendly names
     panelWidth: 340,
     panelMinWidth: 240,
-    panelMaxWidth: 450
+    panelMaxWidth: 960
   });
 
   // Option 2: Auto-detect with basemapStyleUrl (recommended for reliable basemap detection)
@@ -93,7 +93,7 @@ map.on('load', () => {
   //   collapsed: false,
   //   panelWidth: 340,
   //   panelMinWidth: 240,
-  //   panelMaxWidth: 450
+  //   panelMaxWidth: 960
   // });
 
   // Option 4: Manually specify layer states (for full control over names)
@@ -167,8 +167,8 @@ function MapComponent() {
 | `layerStates` | `Record<string, LayerState>` | `undefined` | Manual layer state configuration |
 | `panelWidth` | `number` | `320` | Initial panel width in pixels |
 | `panelMinWidth` | `number` | `240` | Minimum panel width |
-| `panelMaxWidth` | `number` | `420` | Maximum panel width |
-| `panelMaxHeight` | `number` | `600` | Maximum panel height (scrollable when exceeded) |
+| `panelMaxWidth` | `number` | `960` | Maximum panel width |
+| `panelMaxHeight` | `number` | `undefined` | Maximum panel height in pixels. Omit to fill the available vertical space (scrollable only when the layer list is taller than the map) |
 | `showStyleEditor` | `boolean` | `true` | Show gear icon for style editor |
 | `showOpacitySlider` | `boolean` | `true` | Show opacity slider for layers |
 | `showLayerSymbol` | `boolean` | `true` | Show layer type symbols (colored icons) next to layer names |

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -221,7 +221,7 @@
         layers: ['countries-fill', 'countries-outline', 'country-points', 'raster-layer'],
         panelWidth: 320,
         panelMinWidth: 240,
-        panelMaxWidth: 450
+        panelMaxWidth: 960
       });
 
       map.addControl(layerControl, 'top-right');

--- a/examples/dynamic-layers/main.ts
+++ b/examples/dynamic-layers/main.ts
@@ -85,7 +85,7 @@ map.on('load', () => {
     collapsed: false,
     panelWidth: 350,
     panelMinWidth: 240,
-    panelMaxWidth: 450,
+    panelMaxWidth: 960,
     showStyleEditor: true,
     showOpacitySlider: true,
     showLayerSymbol: true,

--- a/examples/full-demo/main.ts
+++ b/examples/full-demo/main.ts
@@ -143,8 +143,8 @@ map.on('load', () => {
     collapsed: false, // Start expanded to show features
     panelWidth: 350,
     panelMinWidth: 240,
-    panelMaxWidth: 450,
-    panelMaxHeight: 400,
+    panelMaxWidth: 960,
+    // panelMaxHeight omitted so the panel fills the available vertical space
     showStyleEditor: true,
     showOpacitySlider: true,
     basemapStyleUrl: BASEMAP_STYLE_URL, // Enables reliable basemap vs user layer detection

--- a/examples/npm-example/main.js
+++ b/examples/npm-example/main.js
@@ -92,7 +92,7 @@ map.on('load', () => {
     layers: ['regions-fill', 'regions-outline', 'regions-points'],
     panelWidth: 350,
     panelMinWidth: 240,
-    panelMaxWidth: 450
+    panelMaxWidth: 960
   });
 
   // Option 2: Auto-detect layers with basemapStyleUrl for reliable detection

--- a/examples/react/App.tsx
+++ b/examples/react/App.tsx
@@ -143,7 +143,7 @@ export default function App() {
           layers={['countries-layer', 'countries-outline', 'country-points']}
           panelWidth={350}
           panelMinWidth={240}
-          panelMaxWidth={450}
+          panelMaxWidth={960}
         />
       )}
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-layer-control",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "A comprehensive layer control for MapLibre GL with advanced styling capabilities",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -1415,8 +1415,35 @@ export class LayerControl implements IControl {
     existingItems.forEach((item) => item.remove());
     this.styleEditors.clear();
 
+    // Render in map stacking order: the top of the panel is the top-most layer
+    // (highest z-index, rendered last) and the bottom is the lowest. The
+    // Background group always sits at the very bottom, matching the basemap
+    // being the bottom-most map layer. Iterating layerStates in insertion order
+    // would instead put Background on top and reverse the user layers, so the
+    // panel order would not match the actual map order (issue #449).
+    const orderedLayerIds = this.getUserLayerIdsInMapOrder();
+
+    // Include any user layers that map-order detection did not capture (e.g.
+    // transient states where the layer is not yet on the map) so nothing
+    // silently disappears from the panel.
+    const captured = new Set(orderedLayerIds);
+    for (const layerId of Object.keys(this.state.layerStates)) {
+      if (layerId !== "Background" && !captured.has(layerId)) {
+        orderedLayerIds.push(layerId);
+      }
+    }
+
+    // Background always renders last so it appears at the bottom of the panel.
+    if (this.state.layerStates["Background"]) {
+      orderedLayerIds.push("Background");
+    }
+
     // Add items for all layers in our state
-    Object.entries(this.state.layerStates).forEach(([layerId, state]) => {
+    orderedLayerIds.forEach((layerId) => {
+      const state = this.state.layerStates[layerId];
+      if (!state) {
+        return;
+      }
       if (
         this.targetLayers.length === 0 ||
         this.targetLayers.includes(layerId)
@@ -2449,7 +2476,8 @@ export class LayerControl implements IControl {
     return styleLayers
       .filter((layer) => {
         if (this.isUserAddedLayer(layer.id)) return false;
-        if (this.excludeDrawnLayers && this.isDrawnLayer(layer.id)) return false;
+        if (this.excludeDrawnLayers && this.isDrawnLayer(layer.id))
+          return false;
         if (this.isExcludedByPattern(layer.id)) return false;
         return true;
       })

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -59,7 +59,8 @@ export class LayerControl implements IControl {
   private minPanelWidth: number;
   private maxPanelWidth: number;
   private initialPanelWidth: number;
-  private maxPanelHeight: number;
+  /** Explicit max panel height; null means fill available vertical space */
+  private maxPanelHeight: number | null;
   private showStyleEditor: boolean;
   private showOpacitySlider: boolean;
   private showLayerSymbol: boolean;
@@ -71,13 +72,6 @@ export class LayerControl implements IControl {
   private nativeLayerGroups: Map<string, string[]> = new Map();
   private basemapStyleUrl: string | null = null;
   private basemapLayerIds: Set<string> | null = null;
-  private widthSliderEl: HTMLElement | null = null;
-  private widthThumbEl: HTMLElement | null = null;
-  private widthValueEl: HTMLElement | null = null;
-  private isWidthSliderActive = false;
-  private widthDragRectWidth: number | null = null;
-  private widthDragStartX: number | null = null;
-  private widthDragStartWidth: number | null = null;
   private widthFrame: number | null = null;
 
   // Exact-opacity input popup
@@ -113,9 +107,12 @@ export class LayerControl implements IControl {
 
   constructor(options: LayerControlOptions = {}) {
     this.minPanelWidth = options.panelMinWidth || 240;
-    this.maxPanelWidth = options.panelMaxWidth || 420;
+    this.maxPanelWidth = options.panelMaxWidth || 960;
     this.initialPanelWidth = options.panelWidth || 350;
-    this.maxPanelHeight = options.panelMaxHeight || 600;
+    // When no explicit max height is given, the panel grows to fill the
+    // available vertical space in the map container (computed in
+    // updatePanelPosition) instead of being capped at a fixed height.
+    this.maxPanelHeight = options.panelMaxHeight ?? null;
     this.showStyleEditor = options.showStyleEditor !== false;
     this.showOpacitySlider = options.showOpacitySlider !== false;
     this.showLayerSymbol = options.showLayerSymbol !== false;
@@ -220,9 +217,6 @@ export class LayerControl implements IControl {
       this.contextMenuEl = this.createContextMenu();
       this.mapContainer.appendChild(this.contextMenuEl);
     }
-
-    // Now that panel is attached, update width display
-    this.updateWidthDisplay();
 
     // Setup event listeners
     this.setupEventListeners();
@@ -769,9 +763,13 @@ export class LayerControl implements IControl {
     const panel = document.createElement("div");
     panel.className = "layer-control-panel";
 
-    // Set initial width and max height directly on the element
+    // Set initial width directly on the element. The max height is computed
+    // dynamically in updatePanelPosition so the panel fills the available
+    // vertical space.
     panel.style.width = `${this.state.panelWidth}px`;
-    panel.style.maxHeight = `${this.maxPanelHeight}px`;
+    if (this.maxPanelHeight != null) {
+      panel.style.maxHeight = `${this.maxPanelHeight}px`;
+    }
 
     if (!this.state.collapsed) {
       panel.classList.add("expanded");
@@ -998,6 +996,25 @@ export class LayerControl implements IControl {
         this.panel.style.right = `${buttonRight}px`;
         break;
     }
+
+    // Let the panel use all the available vertical space in the map container
+    // so a long layer list fills the space before a scrollbar appears, rather
+    // than being capped at a fixed height. A user-provided panelMaxHeight still
+    // caps the panel.
+    const edgeMargin = 8; // keep the panel off the opposite map edge
+    const isTopAnchored = position === "top-left" || position === "top-right";
+    const occupiedFromEdge = isTopAnchored
+      ? buttonTop + buttonRect.height + panelGap
+      : buttonBottom + buttonRect.height + panelGap;
+    const availableHeight = Math.max(
+      120,
+      Math.round(mapRect.height - occupiedFromEdge - edgeMargin),
+    );
+    const maxHeight =
+      this.maxPanelHeight != null
+        ? Math.min(this.maxPanelHeight, availableHeight)
+        : availableHeight;
+    this.panel.style.maxHeight = `${maxHeight}px`;
   }
 
   /**
@@ -1054,7 +1071,8 @@ export class LayerControl implements IControl {
   }
 
   /**
-   * Create the panel header with title and width control
+   * Create the panel header with the title. Panel width is adjusted by
+   * dragging either edge of the panel (see createResizeHandle).
    */
   private createPanelHeader(): HTMLElement {
     const header = document.createElement("div");
@@ -1065,170 +1083,7 @@ export class LayerControl implements IControl {
     title.textContent = "Layers";
     header.appendChild(title);
 
-    // Add width control
-    const widthControl = this.createWidthControl();
-    header.appendChild(widthControl);
-
     return header;
-  }
-
-  /**
-   * Create the width control slider
-   */
-  private createWidthControl(): HTMLElement {
-    const widthControl = document.createElement("label");
-    widthControl.className = "layer-control-width-control";
-    widthControl.title = "Adjust layer panel width";
-
-    const widthLabel = document.createElement("span");
-    widthLabel.textContent = "Width";
-    widthControl.appendChild(widthLabel);
-
-    const widthSlider = document.createElement("div");
-    widthSlider.className = "layer-control-width-slider";
-    widthSlider.setAttribute("role", "slider");
-    widthSlider.setAttribute("aria-valuemin", String(this.minPanelWidth));
-    widthSlider.setAttribute("aria-valuemax", String(this.maxPanelWidth));
-    widthSlider.setAttribute("aria-valuenow", String(this.state.panelWidth));
-    widthSlider.setAttribute("aria-valuestep", "10");
-    widthSlider.setAttribute("aria-label", "Layer panel width");
-    widthSlider.tabIndex = 0;
-
-    const widthTrack = document.createElement("div");
-    widthTrack.className = "layer-control-width-track";
-    const widthThumb = document.createElement("div");
-    widthThumb.className = "layer-control-width-thumb";
-
-    widthSlider.appendChild(widthTrack);
-    widthSlider.appendChild(widthThumb);
-
-    this.widthSliderEl = widthSlider;
-    this.widthThumbEl = widthThumb;
-
-    // Add width value display
-    const widthValue = document.createElement("span");
-    widthValue.className = "layer-control-width-value";
-    this.widthValueEl = widthValue;
-
-    widthControl.appendChild(widthSlider);
-    widthControl.appendChild(widthValue);
-
-    this.updateWidthDisplay();
-    this.setupWidthSliderEvents(widthSlider);
-
-    return widthControl;
-  }
-
-  /**
-   * Setup event listeners for width slider
-   */
-  private setupWidthSliderEvents(widthSlider: HTMLElement): void {
-    // Pointer events for dragging
-    widthSlider.addEventListener("pointerdown", (event) => {
-      event.preventDefault();
-      const rect = widthSlider.getBoundingClientRect();
-      this.widthDragRectWidth = rect.width || 1;
-      this.widthDragStartX = event.clientX;
-      this.widthDragStartWidth = this.state.panelWidth;
-      this.isWidthSliderActive = true;
-      widthSlider.setPointerCapture(event.pointerId);
-      this.updateWidthFromPointer(event, true);
-    });
-
-    widthSlider.addEventListener("pointermove", (event) => {
-      if (!this.isWidthSliderActive) return;
-      this.updateWidthFromPointer(event);
-    });
-
-    const endPointerDrag = (event: PointerEvent) => {
-      if (!this.isWidthSliderActive) return;
-      if (event.pointerId !== undefined) {
-        try {
-          widthSlider.releasePointerCapture(event.pointerId);
-        } catch (error) {
-          // Ignore release errors
-        }
-      }
-      this.isWidthSliderActive = false;
-      this.widthDragRectWidth = null;
-      this.widthDragStartX = null;
-      this.widthDragStartWidth = null;
-      this.updateWidthDisplay();
-    };
-
-    widthSlider.addEventListener("pointerup", endPointerDrag);
-    widthSlider.addEventListener("pointercancel", endPointerDrag);
-    widthSlider.addEventListener("lostpointercapture", endPointerDrag);
-
-    // Keyboard navigation
-    widthSlider.addEventListener("keydown", (event) => {
-      let handled = true;
-      const step = event.shiftKey ? 20 : 10;
-
-      switch (event.key) {
-        case "ArrowLeft":
-        case "ArrowDown":
-          this.applyPanelWidth(this.state.panelWidth - step, true);
-          break;
-        case "ArrowRight":
-        case "ArrowUp":
-          this.applyPanelWidth(this.state.panelWidth + step, true);
-          break;
-        case "Home":
-          this.applyPanelWidth(this.minPanelWidth, true);
-          break;
-        case "End":
-          this.applyPanelWidth(this.maxPanelWidth, true);
-          break;
-        case "PageUp":
-          this.applyPanelWidth(this.state.panelWidth + 50, true);
-          break;
-        case "PageDown":
-          this.applyPanelWidth(this.state.panelWidth - 50, true);
-          break;
-        default:
-          handled = false;
-      }
-
-      if (handled) {
-        event.preventDefault();
-        this.updateWidthDisplay();
-      }
-    });
-  }
-
-  /**
-   * Update panel width from pointer event
-   */
-  private updateWidthFromPointer(
-    event: PointerEvent,
-    resetBaseline = false,
-  ): void {
-    if (!this.widthSliderEl) return;
-
-    const sliderWidth =
-      this.widthDragRectWidth ||
-      this.widthSliderEl.getBoundingClientRect().width ||
-      1;
-    const widthRange = this.maxPanelWidth - this.minPanelWidth;
-
-    let width: number;
-    if (resetBaseline) {
-      const rect = this.widthSliderEl.getBoundingClientRect();
-      const relative =
-        rect.width > 0 ? (event.clientX - rect.left) / rect.width : 0;
-      const clampedRatio = Math.min(1, Math.max(0, relative));
-      width = this.minPanelWidth + clampedRatio * widthRange;
-      this.widthDragStartWidth = width;
-      this.widthDragStartX = event.clientX;
-    } else {
-      const delta = event.clientX - (this.widthDragStartX || event.clientX);
-      width =
-        (this.widthDragStartWidth || this.state.panelWidth) +
-        (delta / sliderWidth) * widthRange;
-    }
-
-    this.applyPanelWidth(width, this.isWidthSliderActive);
   }
 
   /**
@@ -1243,7 +1098,6 @@ export class LayerControl implements IControl {
       this.state.panelWidth = clamped;
       const px = `${clamped}px`;
       this.panel.style.width = px;
-      this.updateWidthDisplay();
     };
 
     if (immediate) {
@@ -1258,38 +1112,6 @@ export class LayerControl implements IControl {
       applyWidth();
       this.widthFrame = null;
     });
-  }
-
-  /**
-   * Update width display (value label and thumb position)
-   */
-  private updateWidthDisplay(): void {
-    if (this.widthValueEl) {
-      this.widthValueEl.textContent = `${this.state.panelWidth}px`;
-    }
-    if (this.widthSliderEl) {
-      this.widthSliderEl.setAttribute(
-        "aria-valuenow",
-        String(this.state.panelWidth),
-      );
-      const ratio =
-        (this.state.panelWidth - this.minPanelWidth) /
-        (this.maxPanelWidth - this.minPanelWidth || 1);
-      if (this.widthThumbEl) {
-        const sliderWidth = this.widthSliderEl.clientWidth;
-        // If element not yet rendered, defer the update
-        if (sliderWidth === 0) {
-          requestAnimationFrame(() => this.updateWidthDisplay());
-          return;
-        }
-        const thumbWidth = this.widthThumbEl.offsetWidth || 14;
-        const padding = 16;
-        const available = Math.max(0, sliderWidth - padding - thumbWidth);
-        const clampedRatio = Math.min(1, Math.max(0, ratio));
-        const leftPx = 8 + available * clampedRatio;
-        this.widthThumbEl.style.left = `${leftPx}px`;
-      }
-    }
   }
 
   /**
@@ -4925,29 +4747,29 @@ export class LayerControl implements IControl {
       }
     });
 
-    // UI shows top layer first, but we need to move layers in reverse order
-    // to maintain the correct stacking
-    const reversedIds = [...uiLayerIds].reverse();
-
-    // Build a set of MapLibre layer IDs for quick lookup
+    // uiLayerIds is the panel order top-to-bottom, where the top row is the
+    // top-most layer (highest z-index, rendered last / on top). MapLibre's
+    // moveLayer(id, beforeId) places `id` visually beneath `beforeId`, so
+    // iterating from the top of the panel downward and anchoring each layer
+    // beneath the previous one reproduces that stacking on the map: the first
+    // item goes to the top, each subsequent item just below it.
     const style = this.map.getStyle();
     const mapLibreLayerIds = new Set(style?.layers?.map((l) => l.id) || []);
 
-    // Move each layer to its correct position
-    for (let i = 0; i < reversedIds.length; i++) {
-      const layerId = reversedIds[i];
+    for (let i = 0; i < uiLayerIds.length; i++) {
+      const layerId = uiLayerIds[i];
 
-      // Check if layer exists in MapLibre (skip custom layers)
+      // Skip custom (non-MapLibre) layers; they are managed by their adapters.
       if (!mapLibreLayerIds.has(layerId)) {
         continue;
       }
 
-      // Find the next MapLibre layer to use as beforeId
-      // Skip any custom layers that might be between this layer and the next
+      // Anchor beneath the nearest higher (already-placed) MapLibre layer,
+      // skipping any custom layers between them.
       let beforeId: string | undefined = undefined;
       for (let j = i - 1; j >= 0; j--) {
-        if (mapLibreLayerIds.has(reversedIds[j])) {
-          beforeId = reversedIds[j];
+        if (mapLibreLayerIds.has(uiLayerIds[j])) {
+          beforeId = uiLayerIds[j];
           break;
         }
       }

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -111,7 +111,7 @@ export interface LayerControlOptions {
   panelWidth?: number;
   /** Minimum panel width in pixels (default: 240) */
   panelMinWidth?: number;
-  /** Maximum panel width in pixels (default: 420) */
+  /** Maximum panel width in pixels (default: 960) */
   panelMaxWidth?: number;
   /** Whether to show the style editor button (gear icon) for layers (default: true) */
   showStyleEditor?: boolean;
@@ -119,7 +119,12 @@ export interface LayerControlOptions {
   showOpacitySlider?: boolean;
   /** Whether to show layer type symbols/icons next to layer names (default: true) */
   showLayerSymbol?: boolean;
-  /** Maximum panel height in pixels (default: 600). When content exceeds this height, the panel becomes scrollable. */
+  /**
+   * Maximum panel height in pixels. When omitted, the panel grows to fill the
+   * available vertical space in the map container and only becomes scrollable
+   * once the layer list is taller than that space. Set an explicit value to
+   * cap the height instead.
+   */
   panelMaxHeight?: number;
   /** Whether to exclude drawn layers from drawing libraries like Geoman, Mapbox GL Draw, etc. (default: true) */
   excludeDrawnLayers?: boolean;

--- a/src/lib/styles/layer-control.css
+++ b/src/lib/styles/layer-control.css
@@ -61,63 +61,6 @@
   font-size: 13px;
 }
 
-/* Width control */
-.layer-control-width-control {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 500;
-  font-size: 11px;
-  color: #5c6a7d;
-  flex-shrink: 0;
-  margin-left: auto;
-}
-
-.layer-control-width-slider {
-  position: relative;
-  width: 130px;
-  height: 16px;
-  border-radius: 8px;
-  cursor: ew-resize;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  touch-action: none;
-  background: transparent;
-  padding: 0 8px;
-  box-sizing: border-box;
-}
-
-.layer-control-width-value {
-  min-width: 44px;
-  text-align: right;
-  font-feature-settings: "tnum";
-  color: #3a4756;
-}
-
-.layer-control-width-track {
-  position: absolute;
-  left: 8px;
-  right: 8px;
-  height: 4px;
-  border-radius: 2px;
-  background: linear-gradient(90deg, #d0d7e2, #2f6fed);
-  pointer-events: none;
-}
-
-.layer-control-width-thumb {
-  position: absolute;
-  top: 50%;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: #fff;
-  border: 2px solid #2f6fed;
-  transform: translateY(-50%);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  pointer-events: none;
-}
-
 /* Edge resize handle — drag the panel edge to resize its width */
 .layer-control-resize-handle {
   position: absolute;

--- a/tests/layerOrder.test.ts
+++ b/tests/layerOrder.test.ts
@@ -79,3 +79,74 @@ describe("panel layer order (issue #449)", () => {
     expect(renderedOrder(control)).toEqual(["user-b", "user-a"]);
   });
 });
+
+/**
+ * Build a control wired to a mock map whose layer array can be reordered via
+ * moveLayer, plus a panel populated with rows in a given top-to-bottom order.
+ * Returns helpers to read the resulting map stacking order.
+ *
+ * @param initialMapOrder Layer IDs in MapLibre array order (index 0 = bottom).
+ * @param panelOrder Layer IDs as rendered top-to-bottom in the panel.
+ */
+function makeReorderControl(initialMapOrder: string[], panelOrder: string[]) {
+  let layers = initialMapOrder.map((id) => ({ id, type: "fill" as const }));
+
+  const mockMap = {
+    getStyle: () => ({ layers }),
+    // MapLibre semantics: moveLayer(id, beforeId) places `id` visually beneath
+    // `beforeId`; with no beforeId the layer moves to the end (top).
+    moveLayer: (id: string, beforeId?: string) => {
+      const item = layers.find((l) => l.id === id);
+      if (!item) return;
+      layers = layers.filter((l) => l.id !== id);
+      if (beforeId === undefined) {
+        layers.push(item);
+      } else {
+        const idx = layers.findIndex((l) => l.id === beforeId);
+        layers.splice(idx < 0 ? layers.length : idx, 0, item);
+      }
+    },
+  };
+
+  const control = new LayerControl({ excludeDrawnLayers: false });
+  const panel = document.createElement("div");
+  for (const id of panelOrder) {
+    const item = document.createElement("div");
+    item.className = "layer-control-item";
+    item.dataset.layerId = id;
+    panel.appendChild(item);
+  }
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (control as any).map = mockMap;
+  (control as any).panel = panel;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  // Map order bottom-to-top; reverse to compare against panel (top-to-bottom).
+  const mapOrderTopToBottom = () => layers.map((l) => l.id).reverse();
+  return { control, mapOrderTopToBottom };
+}
+
+describe("drag reorder applies panel order to the map (issue #449)", () => {
+  it("keeps the map stack matching an unchanged panel order", () => {
+    const { control, mapOrderTopToBottom } = makeReorderControl(
+      ["bg", "a", "b", "c"],
+      ["c", "b", "a", "Background"],
+    );
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (control as any).applyUIOrderToMap();
+    // Panel top (c) must be the top-most map layer; bg stays at the bottom.
+    expect(mapOrderTopToBottom()).toEqual(["c", "b", "a", "bg"]);
+  });
+
+  it("moves a layer dragged to the top of the panel to the top of the map", () => {
+    const { control, mapOrderTopToBottom } = makeReorderControl(
+      ["bg", "a", "b", "c"],
+      ["a", "c", "b", "Background"],
+    );
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (control as any).applyUIOrderToMap();
+    // The panel top row "a" must now cover everything beneath it.
+    expect(mapOrderTopToBottom()).toEqual(["a", "c", "b", "bg"]);
+  });
+});

--- a/tests/layerOrder.test.ts
+++ b/tests/layerOrder.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { LayerControl } from "../src/lib/core/LayerControl";
+
+/**
+ * Build a LayerControl wired to a minimal in-memory mock map so the panel
+ * rendering order can be exercised without a real MapLibre instance.
+ *
+ * @param mapOrder Layer IDs in MapLibre array order (index 0 = bottom-most /
+ *   rendered first, last index = top-most / rendered last).
+ * @param basemapIds IDs that belong to the basemap (grouped under "Background").
+ */
+function makeControl(mapOrder: string[], basemapIds: string[]) {
+  const mockMap = {
+    getStyle: () => ({
+      layers: mapOrder.map((id) => ({ id, type: "fill", source: id })),
+    }),
+    getLayer: (id: string) =>
+      mapOrder.includes(id) ? { id, type: "fill" } : undefined,
+    getLayoutProperty: () => "visible",
+    setLayoutProperty: () => {},
+    getPaintProperty: () => undefined,
+  };
+
+  const control = new LayerControl({
+    excludeDrawnLayers: false,
+    enableDragAndDrop: false,
+    showLayerSymbol: false,
+    showStyleEditor: false,
+    showOpacitySlider: false,
+    enableContextMenu: false,
+  });
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (control as any).map = mockMap;
+  (control as any).panel = document.createElement("div");
+  (control as any).basemapLayerIds = new Set(basemapIds);
+  (control as any).autoDetectLayers();
+  (control as any).buildLayerItems();
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  return control;
+}
+
+/** Read the rendered panel rows top-to-bottom. */
+function renderedOrder(control: LayerControl): string[] {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  const panel: HTMLElement = (control as any).panel;
+  return Array.from(panel.querySelectorAll(".layer-control-item")).map(
+    (el) => (el as HTMLElement).dataset.layerId as string,
+  );
+}
+
+describe("panel layer order (issue #449)", () => {
+  it("renders top-most map layer first and the basemap at the bottom", () => {
+    // Map order (bottom -> top): basemap, user-a, user-b, user-c
+    const control = makeControl(
+      ["osm-basemap", "user-a", "user-b", "user-c"],
+      ["osm-basemap"],
+    );
+
+    // Panel order (top -> bottom): user-c, user-b, user-a, Background
+    expect(renderedOrder(control)).toEqual([
+      "user-c",
+      "user-b",
+      "user-a",
+      "Background",
+    ]);
+  });
+
+  it("keeps the Background group at the bottom with a single user layer", () => {
+    const control = makeControl(["bg", "only-user"], ["bg"]);
+    expect(renderedOrder(control)).toEqual(["only-user", "Background"]);
+  });
+
+  it("renders user layers top-to-bottom when there is no basemap group", () => {
+    // basemapIds references a layer absent from the map, so every map layer is
+    // treated as user-added and no "Background" group is created.
+    const control = makeControl(["user-a", "user-b"], ["absent-basemap"]);
+    expect(renderedOrder(control)).toEqual(["user-b", "user-a"]);
+  });
+});


### PR DESCRIPTION
## Problem

Reported in opengeos/GeoLibre#449: the layer order shown in the layer
control panel did not match the actual map stacking order. The basemap
appeared at the **top** of the panel and user layers were listed
bottom-to-top, the reverse of what users expect (basemap at the bottom,
each subsequent layer stacked on top).

## Root cause

`buildLayerItems()` rendered rows by iterating `this.state.layerStates`
in **insertion order**. `autoDetectLayers()` inserts the `Background`
group first, followed by user layers in MapLibre's native `style.layers`
order (bottom-to-top). Rendering that insertion order directly put
`Background` at the top and reversed the user layers.

The rest of the control already models UI order correctly: the docstring
on `getUserLayerIdsInMapOrder()` ("top to bottom in UI = high z-index to
low") and `applyUIOrderToMap()` ("UI shows top layer first") both assume
the top row is the top-most layer. Only the render path disagreed.

## Fix

`buildLayerItems()` now renders user layers via
`getUserLayerIdsInMapOrder()` (top of panel = highest z-index) and always
appends the `Background` group last so it sits at the bottom, matching the
basemap being the bottom-most map layer. Any user layer not captured by
map-order detection (e.g. a transient state not yet on the map) is still
rendered, so nothing silently disappears.

Because the reorder helpers (`moveLayerUp/Down/Top/Bottom`) and drag-drop
update the map first and then rebuild, the panel stays consistent after
reordering.

## Tests

Added `tests/layerOrder.test.ts` covering:
- basemap renders at the bottom, user layers top-to-bottom
- single user layer + Background group
- no Background group case

Full suite: 49 passing. `npm run build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected layer list and drag reordering to mirror map stacking, with the background group always last.
* **New Features**
  * Panels now grow to available height when max height isn’t set (edge-drag resize still supported).
* **UI/Changes**
  * Removed the layer-control width slider; width is controlled via edge resize.
* **Tests**
  * Added automated coverage for ordering and drag/reorder across basemap and user-layer scenarios.
* **Documentation**
  * Updated README, types docs, and examples; increased default max panel width to 960.
* **Chores**
  * Bumped library version to 0.17.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->