### PR TITLE
fix: order custom-adapter layers by their native map stacking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-layer-control",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A comprehensive layer control for MapLibre GL with advanced styling capabilities",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -4126,29 +4126,51 @@ export class LayerControl implements IControl {
 
     // Get map layers in their actual order (low index = rendered first/bottom)
     const mapLayerIds = style.layers.map((l) => l.id);
+    const indexById = new Map(mapLayerIds.map((id, i) => [id, i]));
 
     // Filter to only user layers that are in our state
     const userLayerIds = Object.keys(this.state.layerStates).filter(
       (id) => id !== "Background",
     );
 
-    // Separate MapLibre layers and custom layers
-    const mapLibreLayers = userLayerIds.filter((id) =>
-      mapLayerIds.includes(id),
-    );
-    const customLayers = userLayerIds.filter(
-      (id) =>
-        this.state.layerStates[id]?.isCustomLayer && !mapLayerIds.includes(id),
-    );
+    // Compute a representative z-position (map index) for every user layer so
+    // that MapLibre layers and custom layers can be ordered together by their
+    // actual stacking order. Custom layers (e.g. deck.gl / raster adapters)
+    // often expose a logical ID that differs from the underlying style layer
+    // IDs, so look those up through the adapter (getNativeLayerIds) and use the
+    // top-most native layer's index. Custom layers with no resolvable native
+    // layer stay on top (Infinity), preserving their relative insertion order.
+    const mapIndexOf = (id: string): number => {
+      const direct = indexById.get(id);
+      if (direct !== undefined) return direct;
 
-    // Sort MapLibre layers by map order (reversed: high index = top in UI)
-    const sortedMapLibreLayers = mapLibreLayers.sort(
-      (a, b) => mapLayerIds.indexOf(b) - mapLayerIds.indexOf(a),
-    );
+      const nativeIds = this.customLayerRegistry?.getNativeLayerIds(id);
+      if (nativeIds && nativeIds.length > 0) {
+        let best = -1;
+        for (const nativeId of nativeIds) {
+          const idx = indexById.get(nativeId);
+          if (idx !== undefined && idx > best) best = idx;
+        }
+        if (best !== -1) return best;
+      }
 
-    // Custom layers are placed at the top (rendered last/on top)
-    // Maintain their relative order from the state
-    return [...customLayers, ...sortedMapLibreLayers];
+      return Number.POSITIVE_INFINITY;
+    };
+
+    // Sort by map index descending (high index = top of UI), keeping the
+    // original insertion order as a stable tiebreaker (notably for unresolved
+    // custom layers that all share an Infinity index).
+    return userLayerIds
+      .map((id, insertionIndex) => ({
+        id,
+        insertionIndex,
+        mapIndex: mapIndexOf(id),
+      }))
+      .sort((a, b) => {
+        if (a.mapIndex !== b.mapIndex) return a.mapIndex > b.mapIndex ? -1 : 1;
+        return a.insertionIndex - b.insertionIndex;
+      })
+      .map((entry) => entry.id);
   }
 
   /**

--- a/tests/layerOrder.test.ts
+++ b/tests/layerOrder.test.ts
@@ -150,3 +150,90 @@ describe("drag reorder applies panel order to the map (issue #449)", () => {
     expect(mapOrderTopToBottom()).toEqual(["a", "c", "b", "bg"]);
   });
 });
+
+/**
+ * Build a control whose user layers are custom-adapter layers (deck.gl / raster
+ * style integrations) whose logical IDs differ from the underlying style layer
+ * IDs. The adapter maps each logical ID to its native layer(s) so map order can
+ * be resolved.
+ *
+ * @param nativeMapOrder Native style layer IDs, bottom-to-top.
+ * @param logicalToNative Logical custom-layer ID -> its native style layer IDs.
+ * @param insertionOrder Logical IDs in the order they were added to the state.
+ */
+function makeCustomControl(
+  nativeMapOrder: string[],
+  logicalToNative: Record<string, string[]>,
+  insertionOrder: string[],
+) {
+  const mockMap = {
+    getStyle: () => ({
+      layers: nativeMapOrder.map((id) => ({ id, type: "raster" })),
+    }),
+    getLayer: (id: string) =>
+      nativeMapOrder.includes(id) ? { id, type: "raster" } : undefined,
+    getLayoutProperty: () => "visible",
+    setLayoutProperty: () => {},
+    getPaintProperty: () => undefined,
+  };
+
+  const adapter = {
+    type: "test",
+    getLayerIds: () => insertionOrder,
+    getLayerState: (id: string) => ({
+      visible: true,
+      opacity: 1,
+      name: id,
+      isCustomLayer: true,
+    }),
+    setVisibility: () => {},
+    setOpacity: () => {},
+    getName: (id: string) => id,
+    getNativeLayerIds: (id: string) => logicalToNative[id] ?? [],
+  };
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const control = new LayerControl({
+    excludeDrawnLayers: false,
+    customLayerAdapters: [adapter as any],
+  });
+  (control as any).map = mockMap;
+  (control as any).panel = document.createElement("div");
+  // Seed the state in the given insertion order, all flagged as custom layers.
+  for (const id of insertionOrder) {
+    (control as any).state.layerStates[id] = {
+      visible: true,
+      opacity: 1,
+      name: id,
+      isCustomLayer: true,
+    };
+  }
+  return {
+    control,
+    order: () => (control as any).getUserLayerIdsInMapOrder() as string[],
+  };
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
+describe("custom-layer order follows the native map stacking (issue #449)", () => {
+  it("orders custom layers by their native layer index, not insertion order", () => {
+    // Native stacking bottom-to-top: bg, layer-A-raster, layer-B-raster.
+    // "A" was added first but sits below "B" on the map, so the panel must
+    // still show B (top) above A.
+    const { order } = makeCustomControl(
+      ["bg", "layer-A-raster", "layer-B-raster"],
+      { A: ["layer-A-raster"], B: ["layer-B-raster"] },
+      ["A", "B"],
+    );
+    expect(order()).toEqual(["B", "A"]);
+  });
+
+  it("keeps custom layers with no resolvable native layer on top in insertion order", () => {
+    const { order } = makeCustomControl(
+      ["bg"],
+      { A: [], B: [] },
+      ["A", "B"],
+    );
+    expect(order()).toEqual(["A", "B"]);
+  });
+});


### PR DESCRIPTION
## Problem

Follow-up to #57 / opengeos/GeoLibre#449. After that fix, **native** MapLibre layers order correctly, but layers added through a **custom adapter** were still shown in the wrong order.

Verified on the GeoLibre deploy preview with Playwright: two raster layers (`RasterA` added first, `TopLayer` added last). The real map stacking has `TopLayer` on top (native layer index 112 vs 111), matching GeoLibre's own panel — but this control's panel showed `RasterA` on top.

## Root cause

`getUserLayerIdsInMapOrder()` placed **all** custom layers at the top of the list in **state insertion order**, ignoring their actual z-position. Integrations like GeoLibre register layers through a `CustomLayerAdapter` whose logical layer ID (e.g. a UUID) differs from the underlying MapLibre style layer IDs (e.g. `layer-<uuid>-raster`). Because the logical ID is not found in `map.getStyle().layers`, every such layer was treated as custom and listed by insertion order rather than map order — so the first-added layer appeared on top even though the last-added layer actually covers it.

## Fix

Resolve a representative map index for **every** user layer:
- native layers use their own index in `style.layers`;
- custom layers use the top-most of their native layers, looked up via the adapter's `getNativeLayerIds`.

Then sort all user layers by that index descending (top of panel = highest z-index), keeping insertion order as a stable tiebreaker for custom layers with no resolvable native layer (these stay on top, as before).

## Tests

Added `custom-layer order follows the native map stacking` cases to `tests/layerOrder.test.ts`:
- custom layers ordered by native index, not insertion order;
- custom layers with no resolvable native layer stay on top in insertion order.

Full suite: 53 passing. `npm run build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layer stacking order so custom layers are positioned according to their actual visual stacking relative to MapLibre layers, rather than always rendering on top.
* **Tests**
  * Added coverage to verify custom-layer ordering (including cases where native layer mapping is not resolvable).
* **Chores**
  * Bumped the package version to 0.17.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->