### PR TITLE
feat: notify consumers when the Background group is toggled

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ function MapComponent() {
 | `enableBackgroundPresets` | `boolean` | `true` | Show the "Saved configurations" controls in the Background Layers panel |
 | `backgroundPresetStorageKey` | `string` | `'maplibre-layer-control:background-presets'` | `localStorage` key under which background visibility presets are stored |
 | `onBackgroundPresetsChange` | `(presets: BackgroundPresets) => void` | `undefined` | Called whenever the saved preset set changes (created or deleted); applying a preset does not change the set, so it does not fire |
+| `onBackgroundVisibilityChange` | `(visible: boolean) => void` | `undefined` | Called when the Background (basemap) group is toggled via the checkbox; mirror it into your own store to keep external basemap UI in sync |
+| `onBackgroundOpacityChange` | `(opacity: number) => void` | `undefined` | Called when the Background (basemap) group opacity slider changes; mirror it into your own store to keep external basemap UI in sync |
 
 ### LayerState
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-layer-control",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A comprehensive layer control for MapLibre GL with advanced styling capabilities",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -99,6 +99,8 @@ export class LayerControl implements IControl {
   ) => void;
   private onLayerReorder?: (layerOrder: string[]) => void;
   private onLayerRemove?: (layerId: string) => void;
+  private onBackgroundVisibilityChange?: (visible: boolean) => void;
+  private onBackgroundOpacityChange?: (opacity: number) => void;
 
   // Background-layer visibility presets
   private enableBackgroundPresets: boolean;
@@ -127,6 +129,8 @@ export class LayerControl implements IControl {
     this.onLayerRename = options.onLayerRename;
     this.onLayerReorder = options.onLayerReorder;
     this.onLayerRemove = options.onLayerRemove;
+    this.onBackgroundVisibilityChange = options.onBackgroundVisibilityChange;
+    this.onBackgroundOpacityChange = options.onBackgroundOpacityChange;
 
     // Background-layer visibility presets
     this.enableBackgroundPresets = options.enableBackgroundPresets !== false;
@@ -1726,6 +1730,9 @@ export class LayerControl implements IControl {
         });
       }
     }
+
+    // Notify consumers so external basemap UI can mirror the new state.
+    this.onBackgroundVisibilityChange?.(visible);
   }
 
   /**
@@ -1747,6 +1754,9 @@ export class LayerControl implements IControl {
         }
       }
     });
+
+    // Notify consumers so external basemap UI can mirror the new opacity.
+    this.onBackgroundOpacityChange?.(opacity);
   }
 
   // ===== Background Legend Methods =====

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -150,6 +150,18 @@ export interface LayerControlOptions {
   /** Callback when a layer is removed via context menu */
   onLayerRemove?: (layerId: string) => void;
   /**
+   * Callback fired when the Background (basemap) group visibility is toggled
+   * via the control's checkbox. Lets consumers mirror the new state into their
+   * own store so external basemap UI (e.g. a separate layer panel) stays in sync.
+   */
+  onBackgroundVisibilityChange?: (visible: boolean) => void;
+  /**
+   * Callback fired when the Background (basemap) group opacity is changed via
+   * the control's slider. Lets consumers mirror the new opacity into their own
+   * store so external basemap UI stays in sync.
+   */
+  onBackgroundOpacityChange?: (opacity: number) => void;
+  /**
    * Whether to show the "Saved configurations" controls in the Background Layers
    * panel, letting users save the current basemap element visibility as a named
    * preset and re-apply it later with one click (default: true).

--- a/tests/backgroundCallbacks.test.ts
+++ b/tests/backgroundCallbacks.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { LayerControl } from "../src/lib/core/LayerControl";
+
+/**
+ * Build a LayerControl wired to a minimal in-memory mock map so the
+ * Background group toggle/opacity handlers can be exercised without a real
+ * MapLibre instance. All known layers are treated as basemap layers.
+ */
+function makeControl(
+  options: ConstructorParameters<typeof LayerControl>[0] = {},
+) {
+  const layerIds = ["water", "roads", "labels"];
+  const layoutProps = new Map<string, string>();
+  const paintProps = new Map<string, number>();
+
+  const mockMap = {
+    getStyle: () => ({
+      layers: layerIds.map((id) => ({ id, type: "fill" })),
+    }),
+    getLayer: (id: string) => ({ id, type: "fill" }),
+    getLayoutProperty: (id: string) => layoutProps.get(id) ?? "visible",
+    setLayoutProperty: (id: string, _prop: string, value: string) => {
+      layoutProps.set(id, value);
+    },
+    getPaintProperty: (id: string) => paintProps.get(id) ?? 1,
+    setPaintProperty: (id: string, _prop: string, value: number) => {
+      paintProps.set(id, value);
+    },
+  };
+
+  const control = new LayerControl(options);
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (control as any).map = mockMap;
+  (control as any).panel = document.createElement("div");
+  (control as any).basemapLayerIds = new Set(layerIds);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  return { control, layoutProps };
+}
+
+describe("background visibility/opacity callbacks", () => {
+  it("fires onBackgroundVisibilityChange when the group is toggled", () => {
+    const onBackgroundVisibilityChange = vi.fn();
+    const { control, layoutProps } = makeControl({
+      onBackgroundVisibilityChange,
+    });
+
+    // Simulate the user unchecking the Background group checkbox.
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (control as any).toggleBackgroundVisibility(false);
+
+    expect(onBackgroundVisibilityChange).toHaveBeenCalledTimes(1);
+    expect(onBackgroundVisibilityChange).toHaveBeenCalledWith(false);
+    // The map layers were actually hidden too.
+    expect(layoutProps.get("water")).toBe("none");
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (control as any).toggleBackgroundVisibility(true);
+    expect(onBackgroundVisibilityChange).toHaveBeenLastCalledWith(true);
+    expect(onBackgroundVisibilityChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires onBackgroundOpacityChange when the group opacity changes", () => {
+    const onBackgroundOpacityChange = vi.fn();
+    const { control } = makeControl({ onBackgroundOpacityChange });
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (control as any).changeBackgroundOpacity(0.4);
+
+    expect(onBackgroundOpacityChange).toHaveBeenCalledTimes(1);
+    expect(onBackgroundOpacityChange).toHaveBeenCalledWith(0.4);
+  });
+
+  it("does not require the callbacks to be provided", () => {
+    const { control } = makeControl();
+    expect(() =>
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      (control as any).toggleBackgroundVisibility(false),
+    ).not.toThrow();
+    expect(() =>
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      (control as any).changeBackgroundOpacity(0.5),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds two opt-in callbacks to `LayerControlOptions`:

- `onBackgroundVisibilityChange?: (visible: boolean) => void`
- `onBackgroundOpacityChange?: (opacity: number) => void`

They fire when the **Background** (basemap) group's visibility checkbox or opacity slider is changed via the control.

## Motivation

The Background group was toggled **entirely internally** — it mutated the MapLibre style and the control's own checkbox/slider, but emitted no event. Consumers that keep basemap visibility/opacity in their own store (e.g. an external layer panel rendered outside the control) had no way to learn about the change, so their UI drifted out of sync.

Per-layer toggles already surface this through custom-layer adapters (`setVisibility`/`setOpacity`); this closes the same gap for the Background group, mirroring the existing `onLayerRename`/`onLayerReorder`/`onLayerRemove` callback pattern.

This was found via GeoLibre issue [#450](https://github.com/giswqs/GeoLibre/issues/450): toggling the basemap in the control did not update the basemap visibility icon in GeoLibre's separate layer panel.

## Behavior / safety

- Both callbacks are optional and invoked with `?.()`, so existing consumers are unaffected.
- They fire only from the user-driven handlers (`toggleBackgroundVisibility`, `changeBackgroundOpacity`). Programmatic state sync writes the control's internal state directly and does **not** go through these handlers, so a consumer that writes back to the control on the callback won't create a feedback loop.

## Tests

- New `tests/backgroundCallbacks.test.ts`: asserts each callback fires with the correct value, that the map layers are actually updated, and that omitting the callbacks does not throw.
- Full suite: **56 passing**.
- README options table updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `onBackgroundVisibilityChange` callback to sync external UI when background layer visibility toggles
  * Added `onBackgroundOpacityChange` callback to sync external UI when background layer opacity changes

* **Documentation**
  * Updated API documentation with new callback options and usage details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->