### PR TITLE
fix: keep new layers and the Background group ordered when added to an open control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-layer-control",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A comprehensive layer control for MapLibre GL with advanced styling capabilities",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -1260,13 +1260,17 @@ export class LayerControl implements IControl {
       orderedLayerIds.push("Background");
     }
 
-    // Add items for all layers in our state
+    // Add items for all layers in our state. The Background group is a synthetic
+    // entry (not a real target layer), so it always renders when present even
+    // when an explicit targetLayers list is in use; otherwise restricting the
+    // control to specific layers would hide the basemap group entirely.
     orderedLayerIds.forEach((layerId) => {
       const state = this.state.layerStates[layerId];
       if (!state) {
         return;
       }
       if (
+        layerId === "Background" ||
         this.targetLayers.length === 0 ||
         this.targetLayers.includes(layerId)
       ) {
@@ -3557,6 +3561,11 @@ export class LayerControl implements IControl {
           (id) => id === "Background" || this.state.layerStates[id],
         );
 
+      // Track whether new layers were added so the panel can be rebuilt in the
+      // correct stacking order afterwards (appending items would otherwise place
+      // a newly added layer at the bottom, below the Background group).
+      let layersAdded = false;
+
       // Find new layers that aren't in our state yet
       const newLayers: string[] = [];
 
@@ -3688,9 +3697,18 @@ export class LayerControl implements IControl {
             opacity: opacity,
             name: this.generateFriendlyName(layerId),
           };
+          // Keep an explicit target-layer list in sync so the rebuilt panel
+          // still renders this layer. An empty list means "show all", so it
+          // must stay empty (pushing would start filtering out other layers
+          // such as the Background group).
+          if (
+            this.targetLayers.length > 0 &&
+            !this.targetLayers.includes(layerId)
+          ) {
+            this.targetLayers.push(layerId);
+          }
 
-          // Add to UI
-          this.addLayerItem(layerId, this.state.layerStates[layerId]);
+          layersAdded = true;
         });
       }
 
@@ -3715,7 +3733,14 @@ export class LayerControl implements IControl {
                 customLayerType:
                   this.customLayerRegistry!.getSymbolType(layerId) || undefined,
               };
-              this.addLayerItem(layerId, this.state.layerStates[layerId]);
+              // See note above: only extend a restricted (non-empty) list.
+              if (
+                this.targetLayers.length > 0 &&
+                !this.targetLayers.includes(layerId)
+              ) {
+                this.targetLayers.push(layerId);
+              }
+              layersAdded = true;
             }
           }
         });
@@ -3742,6 +3767,13 @@ export class LayerControl implements IControl {
             this.styleEditors.delete(layerId);
           }
         });
+      }
+
+      // Rebuild the panel so newly added layers are placed in the correct
+      // stacking order (top of the panel = top-most layer) instead of being
+      // appended below the Background group.
+      if (layersAdded) {
+        this.buildLayerItems();
       }
     } catch (error) {
       console.warn("Failed to check for new layers:", error);

--- a/tests/layerOrder.test.ts
+++ b/tests/layerOrder.test.ts
@@ -215,6 +215,101 @@ function makeCustomControl(
   /* eslint-enable @typescript-eslint/no-explicit-any */
 }
 
+/**
+ * Build a control with only the basemap, then expose a helper to add a new
+ * user layer to the map and run the same detection path the map's `styledata`
+ * event triggers (checkForNewLayers).
+ */
+function makeIncrementalControl() {
+  let layers = [{ id: "bg", type: "fill" }];
+  const mockMap = {
+    getStyle: () => ({ layers }),
+    getLayer: (id: string) => layers.find((l) => l.id === id),
+    getLayoutProperty: () => "visible",
+    setLayoutProperty: () => {},
+    getPaintProperty: () => undefined,
+  };
+
+  const control = new LayerControl({
+    excludeDrawnLayers: false,
+    enableDragAndDrop: false,
+    showLayerSymbol: false,
+    showStyleEditor: false,
+    showOpacitySlider: false,
+    enableContextMenu: false,
+  });
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (control as any).map = mockMap;
+  (control as any).panel = document.createElement("div");
+  (control as any).basemapLayerIds = new Set(["bg"]);
+  // Treat any non-basemap layer as user-added for detection purposes.
+  (control as any).isUserAddedLayer = () => true;
+  (control as any).autoDetectLayers();
+  (control as any).buildLayerItems();
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  return {
+    control,
+    addLayerAndDetect: (id: string) => {
+      layers.push({ id, type: "fill" });
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      (control as any).checkForNewLayers();
+    },
+  };
+}
+
+describe("layers added while the control is open (issue #449)", () => {
+  it("places a newly added layer above the Background group, not below it", () => {
+    const { control, addLayerAndDetect } = makeIncrementalControl();
+    // Initially only the basemap group is shown.
+    expect(renderedOrder(control)).toEqual(["Background"]);
+
+    // Adding a layer after the panel is built must rebuild it in order so the
+    // new layer sits at the top, not appended below Background.
+    addLayerAndDetect("user-1");
+    expect(renderedOrder(control)).toEqual(["user-1", "Background"]);
+
+    // A second added layer goes on top of the first (last added = top-most).
+    addLayerAndDetect("user-2");
+    expect(renderedOrder(control)).toEqual(["user-2", "user-1", "Background"]);
+  });
+
+  it("renders the Background group even with an explicit targetLayers list", () => {
+    // GeoLibre-style usage: the control is restricted to specific user layers
+    // (here a single layer), so targetLayers does not include "Background".
+    // The synthetic Background group must still render at the bottom.
+    const { control } = makeCustomControl(
+      ["bg", "layer-A-raster"],
+      { A: ["layer-A-raster"] },
+      ["A"],
+    );
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (control as any).state.layerStates["Background"] = {
+      visible: true,
+      opacity: 1,
+      name: "Background",
+    };
+    (control as any).targetLayers = ["A"]; // explicit list, no "Background"
+    (control as any).buildLayerItems();
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    expect(renderedOrder(control)).toEqual(["A", "Background"]);
+  });
+
+  it("keeps the Background group when targetLayers is empty (show-all mode)", () => {
+    const { control, addLayerAndDetect } = makeIncrementalControl();
+    // Show-all mode: an empty target list means every layer is rendered. The
+    // rebuild must not start filtering Background out.
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (control as any).targetLayers = [];
+
+    addLayerAndDetect("user-1");
+    expect(renderedOrder(control)).toEqual(["user-1", "Background"]);
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    expect((control as any).targetLayers).toEqual([]);
+  });
+});
+
 describe("custom-layer order follows the native map stacking (issue #449)", () => {
   it("orders custom layers by their native layer index, not insertion order", () => {
     // Native stacking bottom-to-top: bg, layer-A-raster, layer-B-raster.


### PR DESCRIPTION
## Problem

Follow-up to #57 / #58 (opengeos/GeoLibre#449). When a layer was added **while the control already existed** — the normal case in the GeoLibre integration, where layers are added through a custom adapter — the panel order diverged from the map: the new layer landed at the bottom **below** the Background group, or the Background group disappeared entirely.

Reproduced and verified end-to-end by driving the real GeoLibre app with Playwright (open the control, then add an XYZ layer): before this change the control showed `Background` on top of the user layer (or dropped `Background`); after it shows the user layer(s) on top with `Background` at the bottom, matching the left-hand layer panel.

## Root causes & fixes

**1. New layers were appended, not re-ordered.** `checkForNewLayers` added new layers with `addLayerItem` (`appendChild`), so a layer added after the panel was built landed after the Background group at the very bottom. It now records the new layers in state and rebuilds via `buildLayerItems`, which recomputes stacking order. New layers are also added to a **restricted** (non-empty) `targetLayers` list so the rebuild still includes them; an empty list ("show all") is deliberately left untouched so it does not start filtering other layers.

**2. The Background group was subject to the `targetLayers` filter.** Integrations that pass an explicit layer list (GeoLibre) left `targetLayers` without `"Background"`, so the rebuilt panel filtered the synthetic basemap group out. `buildLayerItems` now always renders the `Background` group when present, regardless of the filter.

## Tests

Added cases to `tests/layerOrder.test.ts`:
- a layer added while the control is open is placed above Background (and multiple adds stack correctly);
- the Background group survives a rebuild both with an empty `targetLayers` (show-all) and with an explicit restricted list.

Full suite: 56 passing. `npm run build` passes. Verified in the GeoLibre app via Playwright.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layer stacking order when new layers are added while the layer panel is open
  * Ensured Background group renders at the bottom of the layer list regardless of layer filtering settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->