### PR TITLE
chore(release): 0.17.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-layer-control",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A comprehensive layer control for MapLibre GL with advanced styling capabilities",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Releases the new-layer ordering and Background-group fix from #60 as 0.17.2 collided with the concurrently-released #59. Cuts 0.17.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 0.17.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->