### PR TITLE
feat: notify consumers of per-layer style edits + neutral action buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-layer-control",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-layer-control",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "A comprehensive layer control for MapLibre GL with advanced styling capabilities",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LayerControl.ts
+++ b/src/lib/core/LayerControl.ts
@@ -99,6 +99,11 @@ export class LayerControl implements IControl {
   ) => void;
   private onLayerReorder?: (layerOrder: string[]) => void;
   private onLayerRemove?: (layerId: string) => void;
+  private onLayerStyleChange?: (
+    layerId: string,
+    property: string,
+    value: unknown,
+  ) => void;
   private onBackgroundVisibilityChange?: (visible: boolean) => void;
   private onBackgroundOpacityChange?: (opacity: number) => void;
 
@@ -129,6 +134,7 @@ export class LayerControl implements IControl {
     this.onLayerRename = options.onLayerRename;
     this.onLayerReorder = options.onLayerReorder;
     this.onLayerRemove = options.onLayerRemove;
+    this.onLayerStyleChange = options.onLayerStyleChange;
     this.onBackgroundVisibilityChange = options.onBackgroundVisibilityChange;
     this.onBackgroundOpacityChange = options.onBackgroundOpacityChange;
 
@@ -2640,7 +2646,7 @@ export class LayerControl implements IControl {
 
     const removeBtn = document.createElement("button");
     removeBtn.className = "style-editor-button style-editor-button-remove";
-    removeBtn.textContent = "Remove";
+    removeBtn.textContent = "Remove Layer";
     removeBtn.title = "Remove layer from map";
     removeBtn.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -2750,12 +2756,29 @@ export class LayerControl implements IControl {
 
     const resetBtn = document.createElement("button");
     resetBtn.className = "style-editor-button style-editor-button-reset";
-    resetBtn.textContent = "Reset";
+    resetBtn.textContent = "Reset Style";
     resetBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       // Reset all native sublayers
       for (const nativeId of nativeLayerIds) {
         restoreOriginalStyle(this.map, nativeId, this.state.originalStyles);
+      }
+      // Mirror the restored values to the host before the editor is rebuilt
+      // (closeStyleEditor clears the active editor and group mappings).
+      if (this.onLayerStyleChange) {
+        editor.querySelectorAll("[data-property]").forEach((el) => {
+          const control = el as HTMLElement;
+          const property = control.dataset.property;
+          const sourceId = control.dataset.layerId;
+          if (!property || !sourceId) return;
+          const value = this.map.getPaintProperty(sourceId, property);
+          if (value !== undefined) {
+            this.notifyLayerStyleChange(
+              property,
+              typeof value === "number" ? value : normalizeColor(value),
+            );
+          }
+        });
       }
       // Refresh the editor
       this.closeStyleEditor(layerId);
@@ -2764,7 +2787,7 @@ export class LayerControl implements IControl {
 
     const removeBtn = document.createElement("button");
     removeBtn.className = "style-editor-button style-editor-button-remove";
-    removeBtn.textContent = "Remove";
+    removeBtn.textContent = "Remove Layer";
     removeBtn.title = "Remove layer from map";
     removeBtn.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -2870,7 +2893,7 @@ export class LayerControl implements IControl {
 
     const resetBtn = document.createElement("button");
     resetBtn.className = "style-editor-button style-editor-button-reset";
-    resetBtn.textContent = "Reset";
+    resetBtn.textContent = "Reset Style";
     resetBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       this.resetLayerStyle(layerId);
@@ -2878,7 +2901,7 @@ export class LayerControl implements IControl {
 
     const removeBtn = document.createElement("button");
     removeBtn.className = "style-editor-button style-editor-button-remove";
-    removeBtn.textContent = "Remove";
+    removeBtn.textContent = "Remove Layer";
     removeBtn.title = "Remove layer from map";
     removeBtn.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -3306,6 +3329,89 @@ export class LayerControl implements IControl {
   }
 
   /**
+   * Notify the host that a paint property changed through the style editor.
+   * Reports the layer the active style editor belongs to (`activeStyleEditor`),
+   * not the internal native sub-layer id a control may edit, so consumers can
+   * map the change back to their own layer model.
+   */
+  private notifyLayerStyleChange(property: string, value: unknown): void {
+    const layerId = this.state.activeStyleEditor;
+    if (layerId && this.onLayerStyleChange) {
+      this.onLayerStyleChange(layerId, property, value);
+    }
+  }
+
+  /**
+   * Re-read an open style editor's controls from the current map paint so they
+   * reflect changes made elsewhere (e.g. an external sidebar writing the same
+   * paint properties). Setting input `.value` programmatically does not
+   * dispatch an `input` event, so this never re-triggers
+   * {@link LayerControlOptions.onLayerStyleChange}. The control the user is
+   * actively dragging (the focused input) is left untouched so the refresh
+   * does not fight an in-progress drag.
+   *
+   * @param layerId Restrict the refresh to one layer's editor. Defaults to the
+   *   currently active editor. No-op when that editor is not open.
+   */
+  public refreshStyleEditor(layerId?: string): void {
+    const targetId = layerId ?? this.state.activeStyleEditor;
+    if (!targetId) return;
+    const editor = this.styleEditors.get(targetId);
+    if (editor) {
+      this.syncStyleEditorControlsFromMap(editor);
+    }
+  }
+
+  /**
+   * Update every slider/color control in a style editor from the layer's
+   * current map paint. Each control records the layer it reads from in
+   * `dataset.layerId` (see createSliderControl/createColorControl).
+   */
+  private syncStyleEditorControlsFromMap(editor: HTMLElement): void {
+    const active = document.activeElement;
+
+    const sliders = editor.querySelectorAll(
+      ".style-control-slider",
+    ) as NodeListOf<HTMLInputElement>;
+    sliders.forEach((slider) => {
+      if (slider === active) return;
+      const property = slider.dataset.property;
+      const sourceId = slider.dataset.layerId;
+      if (!property || !sourceId) return;
+      const value = this.map.getPaintProperty(sourceId, property);
+      if (typeof value === "number") {
+        slider.value = String(value);
+        const valueDisplay = slider.parentElement?.querySelector(
+          ".style-control-value",
+        );
+        if (valueDisplay) {
+          const step = parseFloat(slider.step);
+          valueDisplay.textContent = formatNumericValue(value, step);
+        }
+      }
+    });
+
+    const colorPickers = editor.querySelectorAll(
+      ".style-control-color-picker",
+    ) as NodeListOf<HTMLInputElement>;
+    colorPickers.forEach((picker) => {
+      if (picker === active) return;
+      const property = picker.dataset.property;
+      const sourceId = picker.dataset.layerId;
+      if (!property || !sourceId) return;
+      const value = this.map.getPaintProperty(sourceId, property);
+      if (value !== undefined) {
+        const hexColor = normalizeColor(value);
+        picker.value = hexColor;
+        const hexDisplay = picker.parentElement?.querySelector(
+          ".style-control-color-value",
+        ) as HTMLInputElement | null;
+        if (hexDisplay) hexDisplay.value = hexColor;
+      }
+    });
+  }
+
+  /**
    * Create a color control
    */
   private createColorControl(
@@ -3330,6 +3436,10 @@ export class LayerControl implements IControl {
     colorInput.className = "style-control-color-picker";
     colorInput.value = initialValue;
     colorInput.dataset.property = property;
+    // The layer to read this property back from when refreshing the editor
+    // from the map (see refreshStyleEditor). For native sub-layer groups this
+    // is the primary group member; the rest stay in sync with it.
+    colorInput.dataset.layerId = layerId;
 
     const hexDisplay = document.createElement("input");
     hexDisplay.type = "text";
@@ -3344,6 +3454,7 @@ export class LayerControl implements IControl {
       for (const id of targetIds) {
         this.map.setPaintProperty(id, property, color);
       }
+      this.notifyLayerStyleChange(property, color);
     });
 
     inputWrapper.appendChild(colorInput);
@@ -3386,6 +3497,10 @@ export class LayerControl implements IControl {
     slider.step = String(step);
     slider.value = String(initialValue);
     slider.dataset.property = property;
+    // The layer to read this property back from when refreshing the editor
+    // from the map (see refreshStyleEditor). For native sub-layer groups this
+    // is the primary group member; the rest stay in sync with it.
+    slider.dataset.layerId = layerId;
 
     const valueDisplay = document.createElement("span");
     valueDisplay.className = "style-control-value";
@@ -3398,6 +3513,7 @@ export class LayerControl implements IControl {
       for (const id of targetIds) {
         this.map.setPaintProperty(id, property, value);
       }
+      this.notifyLayerStyleChange(property, value);
     });
 
     inputWrapper.appendChild(slider);
@@ -3440,6 +3556,7 @@ export class LayerControl implements IControl {
               const step = parseFloat(slider.step);
               valueDisplay.textContent = formatNumericValue(value, step);
             }
+            this.notifyLayerStyleChange(property, value);
           }
         }
       });
@@ -3458,10 +3575,11 @@ export class LayerControl implements IControl {
             // Update hex display
             const hexDisplay = picker.parentElement?.querySelector(
               ".style-control-color-value",
-            );
+            ) as HTMLInputElement | null;
             if (hexDisplay) {
-              hexDisplay.textContent = hexColor;
+              hexDisplay.value = hexColor;
             }
+            this.notifyLayerStyleChange(property, hexColor);
           }
         }
       });

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -150,6 +150,21 @@ export interface LayerControlOptions {
   /** Callback when a layer is removed via context menu */
   onLayerRemove?: (layerId: string) => void;
   /**
+   * Callback fired whenever a paint property is changed through the per-layer
+   * style editor (a slider/color input, or the Reset button). Reports the
+   * layer the open style editor belongs to (`layerId`), the MapLibre paint
+   * property name (e.g. `"raster-brightness-max"`, `"fill-color"`), and the new
+   * value (a number for sliders, a hex string for color pickers). Lets
+   * consumers mirror the change into their own store so external style UI
+   * (e.g. a separate sidebar) stays in sync. The control still applies the
+   * change to the map itself; this callback is purely a notification.
+   */
+  onLayerStyleChange?: (
+    layerId: string,
+    property: string,
+    value: unknown,
+  ) => void;
+  /**
    * Callback fired when the Background (basemap) group visibility is toggled
    * via the control's checkbox. Lets consumers mirror the new state into their
    * own store so external basemap UI (e.g. a separate layer panel) stays in sync.

--- a/src/lib/styles/layer-control.css
+++ b/src/lib/styles/layer-control.css
@@ -665,6 +665,7 @@
 
 .style-editor-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   justify-content: flex-end;
   padding-top: 8px;
@@ -672,8 +673,8 @@
 }
 
 .style-editor-button {
-  padding: 8px 16px;
-  min-width: 70px;
+  padding: 8px 12px;
+  min-width: 60px;
   border: 1px solid #ddd;
   border-radius: 3px;
   background: white;
@@ -694,43 +695,15 @@
   background: #e0e0e0;
 }
 
-.layer-control-style-editor .style-editor-button-reset {
-  background: #fb923c !important;
-  color: #ffffff !important;
-  border-color: #f97316 !important;
-  font-weight: 600;
-}
-
-.layer-control-style-editor .style-editor-button-reset:hover {
-  background: #f97316 !important;
-  border-color: #ea580c !important;
-  color: #ffffff !important;
-}
-
-.layer-control-style-editor .style-editor-button-close {
-  background: #6b7280 !important;
-  color: #ffffff !important;
-  border-color: #4b5563 !important;
-  font-weight: 600;
-}
-
-.layer-control-style-editor .style-editor-button-close:hover {
-  background: #4b5563 !important;
-  border-color: #374151 !important;
-  color: #ffffff !important;
-}
-
-.layer-control-style-editor .style-editor-button-remove {
-  background: #ef4444 !important;
-  color: #ffffff !important;
-  border-color: #dc2626 !important;
-  font-weight: 600;
-}
-
+/* The Reset / Remove / Close action buttons share the neutral base style above.
+   They intentionally drop the former orange/gray/red fills: consuming apps
+   reserve those signal colors for warnings and errors, so a standard action
+   button should not emit them. The destructive Remove action is confirmed via
+   an inline prompt and only hints its nature with a restrained red on hover. */
 .layer-control-style-editor .style-editor-button-remove:hover {
-  background: #dc2626 !important;
-  border-color: #b91c1c !important;
-  color: #ffffff !important;
+  background: #fef2f2;
+  border-color: #fca5a5;
+  color: #b91c1c;
 }
 
 /* ===== Background Legend Panel ===== */

--- a/tests/layerStyleChange.test.ts
+++ b/tests/layerStyleChange.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from "vitest";
+import { LayerControl } from "../src/lib/core/LayerControl";
+
+/**
+ * Build a LayerControl wired to a minimal in-memory mock map so the per-layer
+ * style-editor controls can be exercised without a real MapLibre instance.
+ */
+function makeControl(
+  options: ConstructorParameters<typeof LayerControl>[0] = {},
+) {
+  const paintProps = new Map<string, unknown>();
+  const key = (id: string, prop: string) => `${id}::${prop}`;
+
+  const mockMap = {
+    getPaintProperty: (id: string, prop: string) =>
+      paintProps.get(key(id, prop)),
+    setPaintProperty: (id: string, prop: string, value: unknown) => {
+      paintProps.set(key(id, prop), value);
+    },
+  };
+
+  const control = new LayerControl(options);
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (control as any).map = mockMap;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  return { control, paintProps, key };
+}
+
+describe("onLayerStyleChange callback", () => {
+  it("fires when a slider control is changed, reporting the active editor's layer id", () => {
+    const onLayerStyleChange = vi.fn();
+    const { control, paintProps, key } = makeControl({ onLayerStyleChange });
+
+    // The editor was opened for the outer layer id, but the slider edits a
+    // native sub-layer id internally — the callback must report the outer id.
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (control as any).state.activeStyleEditor = "geolibre-layer";
+    const container = document.createElement("div");
+    (control as any).createSliderControl(
+      container,
+      "native-primary",
+      "raster-brightness-max",
+      "Brightness Max",
+      1,
+      -1,
+      1,
+      0.05,
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    const slider = container.querySelector(
+      ".style-control-slider",
+    ) as HTMLInputElement;
+    slider.value = "0.4";
+    slider.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // The map was updated...
+    expect(paintProps.get(key("native-primary", "raster-brightness-max"))).toBe(
+      0.4,
+    );
+    // ...and the host was notified with the outer layer id, not the native one.
+    expect(onLayerStyleChange).toHaveBeenCalledTimes(1);
+    expect(onLayerStyleChange).toHaveBeenCalledWith(
+      "geolibre-layer",
+      "raster-brightness-max",
+      0.4,
+    );
+  });
+
+  it("fires when a color control is changed", () => {
+    const onLayerStyleChange = vi.fn();
+    const { control } = makeControl({ onLayerStyleChange });
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (control as any).state.activeStyleEditor = "layer-1";
+    const container = document.createElement("div");
+    (control as any).createColorControl(
+      container,
+      "layer-1",
+      "fill-color",
+      "Fill Color",
+      "#ff0000",
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    const picker = container.querySelector(
+      ".style-control-color-picker",
+    ) as HTMLInputElement;
+    picker.value = "#00ff00";
+    picker.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(onLayerStyleChange).toHaveBeenCalledWith(
+      "layer-1",
+      "fill-color",
+      "#00ff00",
+    );
+  });
+
+  it("does not throw or notify when no callback is provided", () => {
+    const { control } = makeControl();
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (control as any).state.activeStyleEditor = "layer-1";
+    const container = document.createElement("div");
+    (control as any).createSliderControl(
+      container,
+      "layer-1",
+      "raster-opacity",
+      "Opacity",
+      1,
+      0,
+      1,
+      0.05,
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    const slider = container.querySelector(
+      ".style-control-slider",
+    ) as HTMLInputElement;
+    slider.value = "0.5";
+    expect(() =>
+      slider.dispatchEvent(new Event("input", { bubbles: true })),
+    ).not.toThrow();
+  });
+});
+
+describe("refreshStyleEditor", () => {
+  it("re-reads an open editor's slider from the current map paint", () => {
+    const { control, paintProps, key } = makeControl();
+
+    const editor = document.createElement("div");
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (control as any).state.activeStyleEditor = "layer-1";
+    (control as any).styleEditors.set("layer-1", editor);
+    (control as any).createSliderControl(
+      editor,
+      "layer-1",
+      "raster-brightness-max",
+      "Brightness Max",
+      1,
+      -1,
+      1,
+      0.05,
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    const slider = editor.querySelector(
+      ".style-control-slider",
+    ) as HTMLInputElement;
+    expect(slider.value).toBe("1");
+
+    // An external editor (e.g. a sidebar) writes a new value to the map.
+    paintProps.set(key("layer-1", "raster-brightness-max"), 0.3);
+    control.refreshStyleEditor("layer-1");
+
+    expect(slider.value).toBe("0.3");
+    const display = slider.parentElement?.querySelector(".style-control-value");
+    expect(display?.textContent).toBe("0.30");
+  });
+
+  it("is a no-op when the editor is not open", () => {
+    const { control } = makeControl();
+    expect(() => control.refreshStyleEditor("missing")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Lets a host application keep an external style UI in sync with the control's
per-layer style editor, and gives the editor's action buttons a neutral look.
Motivated by opengeos/GeoLibre#912, where edits made in the on-map layer
control's "Edit Style" panel did not reflect in the app's own Style sidebar
(and vice versa), and the orange/red Reset/Remove buttons clashed with the
app's UX guidelines.

## Changes

- **`onLayerStyleChange(layerId, property, value)`** option — fired whenever a
  paint property changes through the style editor (slider/color input, or
  Reset). Reports the layer the editor belongs to (not the internal native
  sub-layer id), the MapLibre paint property name, and the new value. The
  control still applies the change to the map; this is purely a notification so
  consumers can mirror it into their own store.
- **`refreshStyleEditor(layerId?)`** public method — re-reads an open editor's
  controls from the current map paint so the editor reflects changes made
  elsewhere. Skips the input the user is actively dragging and sets values
  programmatically (no `input` event), so it cannot loop with
  `onLayerStyleChange`.
- **Neutral action buttons** — Reset/Remove/Close drop the orange/gray/red
  fills and share the neutral base style. The destructive Remove only hints its
  nature with a restrained red on hover. Buttons relabeled **"Reset Style"** and
  **"Remove Layer"** to make their scope explicit.

## Tests

Adds `tests/layerStyleChange.test.ts` (5 tests) covering the callback firing
for slider and color edits (reporting the active editor's layer id), the
no-callback path, and `refreshStyleEditor` re-reading from the map. Full suite:
64 passing.

Verified end to end in the consuming app (GeoLibre) against a raster layer:
floating editor edits now update the sidebar and vice versa, opacity stays in
sync across the floating editor / sidebar / layer list, and Reset Style
propagates. Confirmed in both light and dark themes.